### PR TITLE
feat: add track deletion and direct mixer fader/panning control

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -239,7 +239,9 @@ class AbletonMCP(ControlSurface):
                                  "manage_clip_automation",
                                  "add_notes_to_arrangement_clip",
                                  "set_device_parameter", "set_device_enabled",
-                                 "delete_device", "navigate_preset"]:
+                                 "delete_device", "navigate_preset",
+                                 "delete_track",
+                                 "set_track_volume", "set_track_panning"]:
                 # Use a thread-safe approach with a response queue
                 response_queue = queue.Queue()
                 
@@ -374,6 +376,17 @@ class AbletonMCP(ControlSurface):
                             ti = params.get("track_index", 0)
                             di = params.get("device_index", 0)
                             result = self._delete_device(ti, di)
+                        elif command_type == "delete_track":
+                            ti = params.get("track_index", 0)
+                            result = self._delete_track(ti)
+                        elif command_type == "set_track_volume":
+                            ti = params.get("track_index", 0)
+                            volume = params.get("volume", 0.85)
+                            result = self._set_track_volume(ti, volume)
+                        elif command_type == "set_track_panning":
+                            ti = params.get("track_index", 0)
+                            panning = params.get("panning", 0.0)
+                            result = self._set_track_panning(ti, panning)
                         elif command_type == "navigate_preset":
                             ti = params.get("track_index", 0)
                             di = params.get("device_index", 0)
@@ -406,6 +419,9 @@ class AbletonMCP(ControlSurface):
                 except queue.Empty:
                     response["status"] = "error"
                     response["message"] = "Timeout waiting for operation to complete"
+            elif command_type == "get_track_volume":
+                ti = params.get("track_index", 0)
+                response["result"] = self._get_track_volume(ti)
             elif command_type == "get_browser_item":
                 uri = params.get("uri", None)
                 path = params.get("path", None)
@@ -652,7 +668,79 @@ class AbletonMCP(ControlSurface):
         except Exception as e:
             self.log_message("Error setting track name: " + str(e))
             raise
-    
+
+    def _get_track_volume(self, track_index):
+        """Get current volume and panning for a track's mixer fader."""
+        try:
+            all_tracks = list(self._song.tracks) + list(self._song.return_tracks)
+            if track_index < 0 or track_index >= len(all_tracks):
+                raise IndexError("Track index {0} out of range (0-{1})".format(
+                    track_index, len(all_tracks) - 1))
+            track = all_tracks[track_index]
+            vol_param = track.mixer_device.volume
+            pan_param = track.mixer_device.panning
+            return {
+                "track_name": track.name,
+                "volume": vol_param.value,
+                "volume_min": vol_param.min,
+                "volume_max": vol_param.max,
+                "panning": pan_param.value,
+                "panning_min": pan_param.min,
+                "panning_max": pan_param.max,
+            }
+        except Exception as e:
+            self.log_message("Error getting track volume: " + str(e))
+            raise
+
+    def _set_track_volume(self, track_index, volume):
+        """Set the mixer fader volume for a track.
+        
+        Args:
+            track_index: 0-based track index (includes return tracks after session tracks)
+            volume: normalized 0.0 (silence) to 1.0 (max). 0.85 = 0dB unity gain.
+        """
+        try:
+            all_tracks = list(self._song.tracks) + list(self._song.return_tracks)
+            if track_index < 0 or track_index >= len(all_tracks):
+                raise IndexError("Track index {0} out of range (0-{1})".format(
+                    track_index, len(all_tracks) - 1))
+            track = all_tracks[track_index]
+            vol_param = track.mixer_device.volume
+            # Clamp to valid range
+            clamped = max(vol_param.min, min(vol_param.max, float(volume)))
+            vol_param.value = clamped
+            return {
+                "track_name": track.name,
+                "volume": vol_param.value,
+            }
+        except Exception as e:
+            self.log_message("Error setting track volume: " + str(e))
+            raise
+
+    def _set_track_panning(self, track_index, panning):
+        """Set the mixer panning for a track.
+        
+        Args:
+            track_index: 0-based track index
+            panning: -1.0 (full left) to +1.0 (full right), 0.0 = center
+        """
+        try:
+            all_tracks = list(self._song.tracks) + list(self._song.return_tracks)
+            if track_index < 0 or track_index >= len(all_tracks):
+                raise IndexError("Track index {0} out of range (0-{1})".format(
+                    track_index, len(all_tracks) - 1))
+            track = all_tracks[track_index]
+            pan_param = track.mixer_device.panning
+            clamped = max(pan_param.min, min(pan_param.max, float(panning)))
+            pan_param.value = clamped
+            return {
+                "track_name": track.name,
+                "panning": pan_param.value,
+            }
+        except Exception as e:
+            self.log_message("Error setting track panning: " + str(e))
+            raise
+
     def _create_clip(self, track_index, clip_index, length):
         """Create a new MIDI clip in the specified track and clip slot"""
         try:
@@ -1566,6 +1654,22 @@ class AbletonMCP(ControlSurface):
             }
         except Exception as e:
             self.log_message("Error deleting device: " + str(e))
+            raise
+
+    def _delete_track(self, track_index):
+        """Delete a track from the session."""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index {0} out of range (0-{1})".format(
+                    track_index, len(self._song.tracks) - 1))
+            track_name = self._song.tracks[track_index].name
+            self._song.delete_track(track_index)
+            return {
+                "deleted_track": track_name,
+                "remaining_tracks": len(self._song.tracks),
+            }
+        except Exception as e:
+            self.log_message("Error deleting track: " + str(e))
             raise
 
     def _navigate_preset(self, track_index, device_index, chain_index=None, direction="current"):

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -116,6 +116,7 @@ class AbletonConnection:
             "add_notes_to_arrangement_clip",
             "set_device_parameter", "set_device_enabled",
             "delete_device", "navigate_preset",
+            "set_track_volume", "set_track_panning",
         ]
         
         try:
@@ -196,7 +197,7 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
 # Create the MCP server with lifespan support
 mcp = FastMCP(
     "AbletonMCP",
-    description="Ableton Live integration through the Model Context Protocol",
+    instructions="Ableton Live integration through the Model Context Protocol",
     lifespan=server_lifespan
 )
 
@@ -386,6 +387,101 @@ def set_track_name(ctx: Context, track_index: int, name: str) -> str:
     except Exception as e:
         logger.error(f"Error setting track name: {str(e)}")
         return f"Error setting track name: {str(e)}"
+
+
+@mcp.tool()
+def get_track_volume(ctx: Context, track_index: int) -> str:
+    """Get the current fader volume and panning for a track.
+
+    Returns the raw normalized value, its min/max range, and the panning.
+    Volume 0.85 = 0 dB unity gain. Use this before set_track_volume to
+    understand the current state.
+
+    Parameters:
+    - track_index: Track number (1-based). Return tracks come after session tracks.
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("get_track_volume", {"track_index": track_index - 1})
+        vol = result.get("volume", 0)
+        pan = result.get("panning", 0)
+        name = result.get("track_name", "?")
+        vol_min = result.get("volume_min", 0)
+        vol_max = result.get("volume_max", 1)
+        # Approximate dB: unity is at 0.85 normalized
+        unity = 0.85
+        if vol > 0:
+            import math
+            db_approx = 20 * math.log10(vol / unity) if vol > 0 else -float('inf')
+            db_str = f"{db_approx:+.1f} dB" if vol > 0 else "-inf dB"
+        else:
+            db_str = "-inf dB"
+        pan_str = "center" if abs(pan) < 0.01 else (f"{abs(pan):.2f} {'L' if pan < 0 else 'R'}")
+        return (
+            f"Track '{name}':\n"
+            f"  Volume: {vol:.4f} (range {vol_min:.2f}–{vol_max:.2f}) ≈ {db_str}\n"
+            f"  Panning: {pan:.4f} ({pan_str})\n"
+            f"  Unity gain (0 dB) = 0.85"
+        )
+    except Exception as e:
+        logger.error(f"Error getting track volume: {str(e)}")
+        return f"Error getting track volume: {str(e)}"
+
+
+@mcp.tool()
+def set_track_volume(ctx: Context, track_index: int, volume: float) -> str:
+    """Set the mixer fader volume for a track directly.
+
+    This controls the actual track fader, not any device parameter.
+
+    Volume scale (normalized):
+      0.0   = silence
+      0.85  = 0 dB (unity gain, Ableton's default fader position)
+      1.0   = maximum (~+6 dB)
+
+    Parameters:
+    - track_index: Track number (1-based). Return tracks come after session tracks.
+    - volume: Normalized volume 0.0–1.0. Use 0.85 for unity (0 dB).
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("set_track_volume", {
+            "track_index": track_index - 1,
+            "volume": volume,
+        })
+        name = result.get("track_name", "?")
+        vol = result.get("volume", volume)
+        import math
+        unity = 0.85
+        db_str = f"{20 * math.log10(vol / unity):+.1f} dB" if vol > 0 else "-inf dB"
+        return f"Set '{name}' fader to {vol:.4f} (≈ {db_str})"
+    except Exception as e:
+        logger.error(f"Error setting track volume: {str(e)}")
+        return f"Error setting track volume: {str(e)}"
+
+
+@mcp.tool()
+def set_track_panning(ctx: Context, track_index: int, panning: float) -> str:
+    """Set the mixer panning for a track.
+
+    Parameters:
+    - track_index: Track number (1-based).
+    - panning: -1.0 = full left, 0.0 = center, +1.0 = full right.
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("set_track_panning", {
+            "track_index": track_index - 1,
+            "panning": panning,
+        })
+        name = result.get("track_name", "?")
+        pan = result.get("panning", panning)
+        pan_str = "center" if abs(pan) < 0.01 else (f"{abs(pan):.2f} {'L' if pan < 0 else 'R'}")
+        return f"Set '{name}' panning to {pan:.4f} ({pan_str})"
+    except Exception as e:
+        logger.error(f"Error setting track panning: {str(e)}")
+        return f"Error setting track panning: {str(e)}"
+
 
 @mcp.tool()
 def create_clip(ctx: Context, track_index: int, clip_index: int, length: float = 4.0) -> str:
@@ -1587,6 +1683,49 @@ def delete_device(
     except Exception as e:
         logger.error(f"Error deleting device: {str(e)}")
         return f"Error deleting device: {str(e)}"
+
+
+@mcp.tool()
+def delete_track(
+    ctx: Context,
+    track_index: int = 0,
+    track_name: str = "",
+) -> str:
+    """Delete a track from the Ableton session.
+
+    Parameters:
+    - track_index: Track number (1-based). Use 0 to resolve by name instead.
+    - track_name: Track name (alternative to track_index). If both are given, track_index takes priority.
+    """
+    try:
+        ableton = get_ableton_connection()
+
+        # Resolve by name if no index given
+        if track_index <= 0:
+            if not track_name:
+                return "Error: provide either track_index (1-based) or track_name."
+            info = ableton.send_command("get_session_info")
+            track_count = info.get("track_count", 0)
+            matched_index = None
+            for i in range(track_count):
+                t = ableton.send_command("get_track_info", {"track_index": i})
+                if t.get("name", "").lower() == track_name.lower():
+                    matched_index = i
+                    break
+            if matched_index is None:
+                return f"Error: No track named '{track_name}' found."
+            ti = matched_index
+        else:
+            ti = track_index - 1  # convert to 0-based
+
+        result = ableton.send_command("delete_track", {"track_index": ti})
+        return "Deleted track '{0}'. {1} tracks remaining.".format(
+            result.get("deleted_track", "unknown"),
+            result.get("remaining_tracks", "?"),
+        )
+    except Exception as e:
+        logger.error(f"Error deleting track: {str(e)}")
+        return f"Error deleting track: {str(e)}"
 
 
 @mcp.tool()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,9 @@ requires-python = ">=3.10"
 authors = [
     {name = "uisato"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [


### PR DESCRIPTION
## Summary

Adds three capabilities that were missing from the MCP server:

1. **Track deletion** — delete a session track by index or name
2. **Mixer fader control** — read and write the actual track volume fader (not device parameters)
3. **Panning control** — read and write track panning from the mixer

---

## Motivation

Previously, `set_device_parameter` was the only way to affect levels, but it only reaches *inside* instrument/effect devices — it cannot move the track's mixer fader. This caused confusion when Claude attempted to mix tracks by adjusting levels, receiving no error but producing no audible change.

---

## New MCP Tools

### `delete_track(track_index, track_name)`
Deletes a session track. Accepts either a 1-based index or a track name (case-insensitive lookup). Returns the deleted track's name and the remaining track count.

### `get_track_volume(track_index)`
Reads the current fader volume and panning from `track.mixer_device`. Returns the raw normalized value, its min/max range, an approximate dB reading, and the current pan position. Useful before setting levels so Claude understands the current state.

### `set_track_volume(track_index, volume)`
Writes directly to `track.mixer_device.volume.value`. Values are clamped to the parameter's reported min/max.

Volume scale:
- `0.0` = silence
- `0.85` = 0 dB (unity gain — Ableton's default fader position)
- `1.0` = ~+6 dB maximum

Works on both session tracks and return tracks (return tracks are indexed after session tracks).

### `set_track_panning(track_index, panning)`
Writes to `track.mixer_device.panning.value`. Scale: `-1.0` = full left, `0.0` = center, `+1.0` = full right.

---

## Implementation Details

**Remote Script (`__init__.py`)**
- Added `set_track_volume`, `set_track_panning`, `delete_track` to the main-thread command list (required for all state-modifying Live API calls per the threading model)
- Added `get_track_volume` to the read-only command router
- Implemented `_get_track_volume`, `_set_track_volume`, `_set_track_panning`, `_delete_track` methods
- Mixer methods index over `list(song.tracks) + list(song.return_tracks)` so return tracks are accessible

**MCP Server (`server.py`)**
- Added `set_track_volume`, `set_track_panning` to the `is_modifying_command` list
- Added all four MCP tool functions with human-readable dB/L/R output
- Fixed FastMCP constructor: renamed `description` kwarg to `instructions` to match `mcp >= 1.27.0` API (upstream breaking change)

---

## Testing
Tested against Ableton Live 12 with the AbletonMCP remote script reloaded via the control surface toggle in preferences.