### PR TITLE
Improve Test Suite and Standardized 1-based indexing across all MCP tools

### DIFF
--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -201,6 +201,40 @@ mcp = FastMCP(
     lifespan=server_lifespan
 )
 
+# ── Index conversion helpers ─────────────────────────────────────
+#
+# Convention: every MCP tool exposes **1-based** indices to callers.
+# The Remote Script expects **0-based** indices.  These helpers
+# enforce the rule in one place so individual tools stay simple.
+
+
+def _to_zero_based(index: int, field_name: str = "index") -> int:
+    """Convert a required 1-based MCP index to 0-based for the Remote Script.
+
+    Raises ValueError when the caller passes 0 or a negative value.
+    """
+    if index < 1:
+        raise ValueError(
+            f"{field_name} must be >= 1 (1-based), got {index}"
+        )
+    return index - 1
+
+
+def _optional_to_zero_based(index: int, field_name: str = "index") -> int | None:
+    """Convert an optional 1-based index to 0-based.
+
+    Returns None when *index* is 0 (meaning "not specified").
+    Raises ValueError for negative values.
+    """
+    if index < 0:
+        raise ValueError(
+            f"{field_name} must be >= 0 (0 = unset, 1+ = 1-based), got {index}"
+        )
+    if index == 0:
+        return None
+    return index - 1
+
+
 # Parameter normalization utilities
 
 
@@ -342,13 +376,14 @@ def get_session_info(ctx: Context) -> str:
 def get_track_info(ctx: Context, track_index: int) -> str:
     """
     Get detailed information about a specific track in Ableton.
-    
+
     Parameters:
-    - track_index: The index of the track to get information about
+    - track_index: Track number (1-based).
     """
     try:
         ableton = get_ableton_connection()
-        result = ableton.send_command("get_track_info", {"track_index": track_index})
+        ti = _to_zero_based(track_index, "track_index")
+        result = ableton.send_command("get_track_info", {"track_index": ti})
         return json.dumps(result, indent=2)
     except Exception as e:
         logger.error(f"Error getting track info from Ableton: {str(e)}")
@@ -375,14 +410,15 @@ def create_midi_track(ctx: Context, index: int = -1) -> str:
 def set_track_name(ctx: Context, track_index: int, name: str) -> str:
     """
     Set the name of a track.
-    
+
     Parameters:
-    - track_index: The index of the track to rename
-    - name: The new name for the track
+    - track_index: Track number (1-based).
+    - name: The new name for the track.
     """
     try:
         ableton = get_ableton_connection()
-        result = ableton.send_command("set_track_name", {"track_index": track_index, "name": name})
+        ti = _to_zero_based(track_index, "track_index")
+        result = ableton.send_command("set_track_name", {"track_index": ti, "name": name})
         return f"Renamed track to: {result.get('name', name)}"
     except Exception as e:
         logger.error(f"Error setting track name: {str(e)}")
@@ -402,7 +438,8 @@ def get_track_volume(ctx: Context, track_index: int) -> str:
     """
     try:
         ableton = get_ableton_connection()
-        result = ableton.send_command("get_track_volume", {"track_index": track_index - 1})
+        ti = _to_zero_based(track_index, "track_index")
+        result = ableton.send_command("get_track_volume", {"track_index": ti})
         vol = result.get("volume", 0)
         pan = result.get("panning", 0)
         name = result.get("track_name", "?")
@@ -445,8 +482,9 @@ def set_track_volume(ctx: Context, track_index: int, volume: float) -> str:
     """
     try:
         ableton = get_ableton_connection()
+        ti = _to_zero_based(track_index, "track_index")
         result = ableton.send_command("set_track_volume", {
-            "track_index": track_index - 1,
+            "track_index": ti,
             "volume": volume,
         })
         name = result.get("track_name", "?")
@@ -470,8 +508,9 @@ def set_track_panning(ctx: Context, track_index: int, panning: float) -> str:
     """
     try:
         ableton = get_ableton_connection()
+        ti = _to_zero_based(track_index, "track_index")
         result = ableton.send_command("set_track_panning", {
-            "track_index": track_index - 1,
+            "track_index": ti,
             "panning": panning,
         })
         name = result.get("track_name", "?")
@@ -487,17 +526,19 @@ def set_track_panning(ctx: Context, track_index: int, panning: float) -> str:
 def create_clip(ctx: Context, track_index: int, clip_index: int, length: float = 4.0) -> str:
     """
     Create a new MIDI clip in the specified track and clip slot.
-    
+
     Parameters:
-    - track_index: The index of the track to create the clip in
-    - clip_index: The index of the clip slot to create the clip in
-    - length: The length of the clip in beats (default: 4.0)
+    - track_index: Track number (1-based).
+    - clip_index: Clip slot number (1-based).
+    - length: The length of the clip in beats (default: 4.0).
     """
     try:
         ableton = get_ableton_connection()
+        ti = _to_zero_based(track_index, "track_index")
+        ci = _to_zero_based(clip_index, "clip_index")
         result = ableton.send_command("create_clip", {
-            "track_index": track_index, 
-            "clip_index": clip_index, 
+            "track_index": ti,
+            "clip_index": ci,
             "length": length
         })
         return f"Created new clip at track {track_index}, slot {clip_index} with length {length} beats"
@@ -507,24 +548,26 @@ def create_clip(ctx: Context, track_index: int, clip_index: int, length: float =
 
 @mcp.tool()
 def add_notes_to_clip(
-    ctx: Context, 
-    track_index: int, 
-    clip_index: int, 
+    ctx: Context,
+    track_index: int,
+    clip_index: int,
     notes: List[Dict[str, Union[int, float, bool]]]
 ) -> str:
     """
     Add MIDI notes to a clip.
-    
+
     Parameters:
-    - track_index: The index of the track containing the clip
-    - clip_index: The index of the clip slot containing the clip
-    - notes: List of note dictionaries, each with pitch, start_time, duration, velocity, and mute
+    - track_index: Track number (1-based).
+    - clip_index: Clip slot number (1-based).
+    - notes: List of note dictionaries, each with pitch, start_time, duration, velocity, and mute.
     """
     try:
         ableton = get_ableton_connection()
+        ti = _to_zero_based(track_index, "track_index")
+        ci = _to_zero_based(clip_index, "clip_index")
         result = ableton.send_command("add_notes_to_clip", {
-            "track_index": track_index,
-            "clip_index": clip_index,
+            "track_index": ti,
+            "clip_index": ci,
             "notes": notes
         })
         return f"Added {len(notes)} notes to clip at track {track_index}, slot {clip_index}"
@@ -536,17 +579,19 @@ def add_notes_to_clip(
 def set_clip_name(ctx: Context, track_index: int, clip_index: int, name: str) -> str:
     """
     Set the name of a clip.
-    
+
     Parameters:
-    - track_index: The index of the track containing the clip
-    - clip_index: The index of the clip slot containing the clip
-    - name: The new name for the clip
+    - track_index: Track number (1-based).
+    - clip_index: Clip slot number (1-based).
+    - name: The new name for the clip.
     """
     try:
         ableton = get_ableton_connection()
+        ti = _to_zero_based(track_index, "track_index")
+        ci = _to_zero_based(clip_index, "clip_index")
         result = ableton.send_command("set_clip_name", {
-            "track_index": track_index,
-            "clip_index": clip_index,
+            "track_index": ti,
+            "clip_index": ci,
             "name": name
         })
         return f"Renamed clip at track {track_index}, slot {clip_index} to '{name}'"
@@ -575,15 +620,16 @@ def set_tempo(ctx: Context, tempo: float) -> str:
 def load_instrument_or_effect(ctx: Context, track_index: int, uri: str) -> str:
     """
     Load an instrument or effect onto a track using its URI.
-    
+
     Parameters:
-    - track_index: The index of the track to load the instrument on
-    - uri: The URI of the instrument or effect to load (e.g., 'query:Synths#Instrument%20Rack:Bass:FileId_5116')
+    - track_index: Track number (1-based).
+    - uri: The URI of the instrument or effect to load (e.g., 'query:Synths#Instrument%20Rack:Bass:FileId_5116').
     """
     try:
         ableton = get_ableton_connection()
+        ti = _to_zero_based(track_index, "track_index")
         result = ableton.send_command("load_browser_item", {
-            "track_index": track_index,
+            "track_index": ti,
             "item_uri": uri
         })
         
@@ -605,16 +651,18 @@ def load_instrument_or_effect(ctx: Context, track_index: int, uri: str) -> str:
 def fire_clip(ctx: Context, track_index: int, clip_index: int) -> str:
     """
     Start playing a clip.
-    
+
     Parameters:
-    - track_index: The index of the track containing the clip
-    - clip_index: The index of the clip slot containing the clip
+    - track_index: Track number (1-based).
+    - clip_index: Clip slot number (1-based).
     """
     try:
         ableton = get_ableton_connection()
+        ti = _to_zero_based(track_index, "track_index")
+        ci = _to_zero_based(clip_index, "clip_index")
         result = ableton.send_command("fire_clip", {
-            "track_index": track_index,
-            "clip_index": clip_index
+            "track_index": ti,
+            "clip_index": ci
         })
         return f"Started playing clip at track {track_index}, slot {clip_index}"
     except Exception as e:
@@ -625,16 +673,18 @@ def fire_clip(ctx: Context, track_index: int, clip_index: int) -> str:
 def stop_clip(ctx: Context, track_index: int, clip_index: int) -> str:
     """
     Stop playing a clip.
-    
+
     Parameters:
-    - track_index: The index of the track containing the clip
-    - clip_index: The index of the clip slot containing the clip
+    - track_index: Track number (1-based).
+    - clip_index: Clip slot number (1-based).
     """
     try:
         ableton = get_ableton_connection()
+        ti = _to_zero_based(track_index, "track_index")
+        ci = _to_zero_based(clip_index, "clip_index")
         result = ableton.send_command("stop_clip", {
-            "track_index": track_index,
-            "clip_index": clip_index
+            "track_index": ti,
+            "clip_index": ci
         })
         return f"Stopped clip at track {track_index}, slot {clip_index}"
     except Exception as e:
@@ -771,18 +821,19 @@ def get_browser_items_at_path(ctx: Context, path: str) -> str:
 def load_drum_kit(ctx: Context, track_index: int, rack_uri: str, kit_path: str) -> str:
     """
     Load a drum rack and then load a specific drum kit into it.
-    
+
     Parameters:
-    - track_index: The index of the track to load on
-    - rack_uri: The URI of the drum rack to load (e.g., 'Drums/Drum Rack')
-    - kit_path: Path to the drum kit inside the browser (e.g., 'drums/acoustic/kit1')
+    - track_index: Track number (1-based).
+    - rack_uri: The URI of the drum rack to load (e.g., 'Drums/Drum Rack').
+    - kit_path: Path to the drum kit inside the browser (e.g., 'drums/acoustic/kit1').
     """
     try:
         ableton = get_ableton_connection()
-        
+        ti = _to_zero_based(track_index, "track_index")
+
         # Step 1: Load the drum rack
         result = ableton.send_command("load_browser_item", {
-            "track_index": track_index,
+            "track_index": ti,
             "item_uri": rack_uri
         })
         
@@ -807,7 +858,7 @@ def load_drum_kit(ctx: Context, track_index: int, rack_uri: str, kit_path: str) 
         # Step 4: Load the first loadable kit
         kit_uri = loadable_kits[0].get("uri")
         load_result = ableton.send_command("load_browser_item", {
-            "track_index": track_index,
+            "track_index": ti,
             "item_uri": kit_uri
         })
         
@@ -845,8 +896,8 @@ def get_arrangement_info(ctx: Context, track_index: int = 0) -> str:
     """
     try:
         ableton = get_ableton_connection()
-        idx = track_index - 1 if track_index > 0 else -1
-        result = ableton.send_command("get_arrangement_info", {"track_index": idx})
+        idx = _optional_to_zero_based(track_index, "track_index")
+        result = ableton.send_command("get_arrangement_info", {"track_index": idx if idx is not None else -1})
 
         num = result.get("transport", {}).get("signature_numerator", 4)
         denom = result.get("transport", {}).get("signature_denominator", 4)
@@ -1067,8 +1118,9 @@ def create_arrangement_midi_clip(
             position = start_beat
             length = length_beats
 
+        ti = _to_zero_based(track_index, "track_index")
         result = ableton.send_command("create_arrangement_clip", {
-            "track_index": track_index - 1,
+            "track_index": ti,
             "position": position,
             "length": length,
         })
@@ -1107,8 +1159,9 @@ def create_arrangement_audio_clip(
         ableton = get_ableton_connection()
         position = _convert_bar_to_beat(start_bar, start_beat)
 
+        ti = _to_zero_based(track_index, "track_index")
         result = ableton.send_command("create_arrangement_audio_clip", {
-            "track_index": track_index - 1,
+            "track_index": ti,
             "position": position,
             "file_path": file_path,
         })
@@ -1138,9 +1191,11 @@ def duplicate_clip_to_arrangement(
         ableton = get_ableton_connection()
         dest = _convert_bar_to_beat(destination_bar, destination_beat)
 
+        ti = _to_zero_based(track_index, "track_index")
+        ci = _to_zero_based(clip_index, "clip_index")
         result = ableton.send_command("duplicate_to_arrangement", {
-            "track_index": track_index - 1,
-            "clip_index": clip_index - 1,
+            "track_index": ti,
+            "clip_index": ci,
             "destination_time": dest,
         })
         return f"Duplicated session clip to arrangement on track {track_index}" + _ARRANGEMENT_TIP
@@ -1165,11 +1220,12 @@ def delete_arrangement_clip(
     """
     try:
         ableton = get_ableton_connection()
-        params = {"track_index": track_index - 1}
+        ti = _to_zero_based(track_index, "track_index")
+        params = {"track_index": ti}
         if clip_name:
             params["clip_name"] = clip_name
         elif clip_index > 0:
-            params["clip_index"] = clip_index - 1
+            params["clip_index"] = _to_zero_based(clip_index, "clip_index")
         else:
             return "Error: provide clip_index or clip_name"
 
@@ -1219,8 +1275,8 @@ def set_arrangement_clip_property(
     """
     try:
         ableton = get_ableton_connection()
-        ci = clip_index - 1 if clip_index > 0 else 0
-        ti = track_index - 1
+        ti = _to_zero_based(track_index, "track_index")
+        ci = _to_zero_based(clip_index, "clip_index") if clip_index > 0 else 0
 
         props = {
             "name": name, "muted": muted, "color": color, "looping": looping,
@@ -1278,10 +1334,10 @@ def control_arrangement_view(ctx: Context, action: str, track_index: int = 0) ->
     """
     try:
         ableton = get_ableton_connection()
-        ti = track_index - 1 if track_index > 0 else 0
+        ti = _optional_to_zero_based(track_index, "track_index")
         result = ableton.send_command("control_arrangement_view", {
             "action": action,
-            "track_index": ti,
+            "track_index": ti if ti is not None else 0,
         })
         return f"Arrangement view: {action} done"
     except Exception as e:
@@ -1309,9 +1365,11 @@ def manage_clip_automation(
     """
     try:
         ableton = get_ableton_connection()
+        ti = _to_zero_based(track_index, "track_index")
+        ci = _to_zero_based(clip_index, "clip_index") if clip_index > 0 else 0
         result = ableton.send_command("manage_clip_automation", {
-            "track_index": track_index - 1,
-            "clip_index": clip_index - 1 if clip_index > 0 else 0,
+            "track_index": ti,
+            "clip_index": ci,
             "action": action,
             "parameter_name": parameter_name,
         })
@@ -1351,10 +1409,12 @@ def get_device_parameters(
         from MCP_Server.plugin_aliases import get_categories, get_alias_for_param
 
         ableton = get_ableton_connection()
-        ci = chain_index - 1 if chain_index > 0 else None
+        ti = _to_zero_based(track_index, "track_index")
+        di = _to_zero_based(device_index, "device_index")
+        ci = _optional_to_zero_based(chain_index, "chain_index")
         result = ableton.send_command("get_device_parameters", {
-            "track_index": track_index - 1,
-            "device_index": device_index - 1,
+            "track_index": ti,
+            "device_index": di,
             "chain_index": ci,
             "show_all": True,  # Always get full list from RS, group MCP-side
         })
@@ -1439,16 +1499,19 @@ def set_device_parameter(
         from MCP_Server.plugin_aliases import resolve_alias
 
         ableton = get_ableton_connection()
+        ti = _to_zero_based(track_index, "track_index")
+        di = _to_zero_based(device_index, "device_index")
+        ci = _optional_to_zero_based(chain_index, "chain_index")
+        pi = _optional_to_zero_based(parameter_index, "parameter_index")
 
         # Resolve alias if parameter_name is provided
         resolved_name = parameter_name
         alias_used = None
         if parameter_name:
             # First get device name for alias resolution
-            ci = chain_index - 1 if chain_index > 0 else None
             info = ableton.send_command("get_device_parameters", {
-                "track_index": track_index - 1,
-                "device_index": device_index - 1,
+                "track_index": ti,
+                "device_index": di,
                 "chain_index": ci,
                 "show_all": False,
             })
@@ -1459,11 +1522,11 @@ def set_device_parameter(
                 resolved_name = real_name
 
         result = ableton.send_command("set_device_parameter", {
-            "track_index": track_index - 1,
-            "device_index": device_index - 1,
-            "chain_index": chain_index - 1 if chain_index > 0 else None,
+            "track_index": ti,
+            "device_index": di,
+            "chain_index": ci,
             "parameter_name": resolved_name if resolved_name else None,
-            "parameter_index": parameter_index - 1 if parameter_index > 0 else None,
+            "parameter_index": pi,
             "value": value,
         })
 
@@ -1525,12 +1588,13 @@ def _toggle_device(track_index, device_index, device_name, chain_index, enabled)
     """Shared logic for enable/disable device."""
     try:
         ableton = get_ableton_connection()
-
-        di = device_index - 1 if device_index > 0 else 0
+        ti = _to_zero_based(track_index, "track_index")
+        di = _optional_to_zero_based(device_index, "device_index")
+        ci = _optional_to_zero_based(chain_index, "chain_index")
 
         # If device_name provided, resolve to index
-        if device_name and device_index <= 0:
-            info = ableton.send_command("get_track_info", {"track_index": track_index - 1})
+        if device_name and di is None:
+            info = ableton.send_command("get_track_info", {"track_index": ti})
             devices = info.get("devices", [])
             matches = [d for d in devices if d["name"].lower() == device_name.lower()]
             if len(matches) == 0:
@@ -1540,11 +1604,13 @@ def _toggle_device(track_index, device_index, device_name, chain_index, enabled)
                 return "Error: Multiple devices named '{0}' on track {1}: {2}".format(
                     device_name, track_index, match_list)
             di = matches[0]["index"]
+        elif di is None:
+            di = 0
 
         result = ableton.send_command("set_device_enabled", {
-            "track_index": track_index - 1,
+            "track_index": ti,
             "device_index": di,
-            "chain_index": chain_index - 1 if chain_index > 0 else None,
+            "chain_index": ci,
             "enabled": enabled,
         })
 
@@ -1572,10 +1638,13 @@ def get_chain_info(
     """
     try:
         ableton = get_ableton_connection()
+        ti = _to_zero_based(track_index, "track_index")
+        di = _to_zero_based(device_index, "device_index")
+        ci = _optional_to_zero_based(chain_index, "chain_index")
         result = ableton.send_command("get_chain_info", {
-            "track_index": track_index - 1,
-            "device_index": device_index - 1,
-            "chain_index": chain_index - 1 if chain_index > 0 else None,
+            "track_index": ti,
+            "device_index": di,
+            "chain_index": ci,
         })
 
         if chain_index > 0:
@@ -1617,9 +1686,11 @@ def get_drum_pad_info(ctx: Context, track_index: int, device_index: int = 1) -> 
     """
     try:
         ableton = get_ableton_connection()
+        ti = _to_zero_based(track_index, "track_index")
+        di = _to_zero_based(device_index, "device_index")
         result = ableton.send_command("get_drum_pad_info", {
-            "track_index": track_index - 1,
-            "device_index": device_index - 1,
+            "track_index": ti,
+            "device_index": di,
         })
 
         device_name = result.get("device_name", "?")
@@ -1657,12 +1728,12 @@ def delete_device(
     """
     try:
         ableton = get_ableton_connection()
-
-        di = device_index - 1 if device_index > 0 else 0
+        ti = _to_zero_based(track_index, "track_index")
+        di = _optional_to_zero_based(device_index, "device_index")
 
         # Resolve by name if needed
-        if device_name and device_index <= 0:
-            info = ableton.send_command("get_track_info", {"track_index": track_index - 1})
+        if device_name and di is None:
+            info = ableton.send_command("get_track_info", {"track_index": ti})
             devices = info.get("devices", [])
             matches = [d for d in devices if d["name"].lower() == device_name.lower()]
             if len(matches) == 0:
@@ -1671,9 +1742,11 @@ def delete_device(
                 match_list = ", ".join("{0} (index {1})".format(d["name"], d["index"] + 1) for d in matches)
                 return "Error: Multiple devices named '{0}': {1}".format(device_name, match_list)
             di = matches[0]["index"]
+        elif di is None:
+            di = 0
 
         result = ableton.send_command("delete_device", {
-            "track_index": track_index - 1,
+            "track_index": ti,
             "device_index": di,
         })
 
@@ -1716,7 +1789,7 @@ def delete_track(
                 return f"Error: No track named '{track_name}' found."
             ti = matched_index
         else:
-            ti = track_index - 1  # convert to 0-based
+            ti = _to_zero_based(track_index, "track_index")
 
         result = ableton.send_command("delete_track", {"track_index": ti})
         return "Deleted track '{0}'. {1} tracks remaining.".format(
@@ -1746,10 +1819,13 @@ def navigate_device_preset(
     """
     try:
         ableton = get_ableton_connection()
+        ti = _to_zero_based(track_index, "track_index")
+        di = _to_zero_based(device_index, "device_index")
+        ci = _optional_to_zero_based(chain_index, "chain_index")
         result = ableton.send_command("navigate_preset", {
-            "track_index": track_index - 1,
-            "device_index": device_index - 1,
-            "chain_index": chain_index - 1 if chain_index > 0 else None,
+            "track_index": ti,
+            "device_index": di,
+            "chain_index": ci,
             "direction": direction,
         })
 

--- a/tests/unit/test_arrangement_commands.py
+++ b/tests/unit/test_arrangement_commands.py
@@ -26,23 +26,26 @@ class TestConvertBarToBeat:
 
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     def test_bar_takes_precedence(self, mock_ts):
+        # When both bar and beat are provided, bar should take precedence
         assert _convert_bar_to_beat(5, 99.0) == 16.0
 
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     def test_bar_zero_uses_beat(self, mock_ts):
+        # When bar is 0 (unset), the raw beat value should be used instead
         assert _convert_bar_to_beat(0, 12.0) == 12.0
 
     @patch('MCP_Server.server._get_time_signature', return_value=(3, 4))
     def test_bar_with_3_4(self, mock_ts):
+        # Bar conversion should respect a 3/4 time signature
         assert _convert_bar_to_beat(5, 0.0) == 12.0
 
 
 class TestGetArrangementInfoCommand:
-    """T016: Test get_arrangement_info command dict construction."""
+    """Test get_arrangement_info command dict construction."""
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_track_0_sends_minus_1(self, mock_conn):
-        """track_index=0 (all tracks) should send -1 to RS."""
+        """track_index=0 (all tracks) should send -1 to the Remote Script."""
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "transport": {"tempo": 120, "signature_numerator": 4,
@@ -60,7 +63,7 @@ class TestGetArrangementInfoCommand:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_track_3_sends_2(self, mock_conn):
-        """track_index=3 (1-based) should send 2 (0-based) to RS."""
+        """track_index=3 (1-based) should convert to 2 (0-based) for the Remote Script."""
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "transport": {"tempo": 120, "signature_numerator": 4,
@@ -78,7 +81,7 @@ class TestGetArrangementInfoCommand:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_get_cue_points_command(self, mock_conn):
-        """get_cue_points should send correct command."""
+        """get_cue_points should send the correct command with no index params."""
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"cue_points": []}
         mock_conn.return_value = mock_ableton
@@ -90,11 +93,12 @@ class TestGetArrangementInfoCommand:
 
 
 class TestSetSongTimeCommand:
-    """T028: Test set_song_time command construction."""
+    """Test set_song_time command construction."""
 
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')
     def test_bar_8_sends_beat_28(self, mock_conn, mock_ts):
+        # Bar 8 in 4/4 = (8-1)*4 = beat 28.0; verify the RS receives this value
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"time": 28.0}
         mock_conn.return_value = mock_ableton
@@ -108,6 +112,7 @@ class TestSetSongTimeCommand:
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')
     def test_beat_direct(self, mock_conn, mock_ts):
+        # When bar=0, the raw beat value should be sent directly to the RS
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"time": 12.0}
         mock_conn.return_value = mock_ableton
@@ -120,11 +125,12 @@ class TestSetSongTimeCommand:
 
 
 class TestSetArrangementLoopCommand:
-    """T028: Test set_arrangement_loop command construction."""
+    """Test set_arrangement_loop command construction."""
 
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')
     def test_bar_range(self, mock_conn, mock_ts):
+        # Bars 4–8 in 4/4: start=12.0, length=16.0; verify correct loop region
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "enabled": True, "start": 12.0, "length": 16.0}
@@ -141,10 +147,11 @@ class TestSetArrangementLoopCommand:
 
 
 class TestJumpToCuePointCommand:
-    """T028: Test jump_to_cue_point command construction."""
+    """Test jump_to_cue_point command construction."""
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_direction_next(self, mock_conn):
+        # Jumping by direction should send the direction string to the RS
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"direction": "next"}
         mock_conn.return_value = mock_ableton
@@ -157,6 +164,7 @@ class TestJumpToCuePointCommand:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_name(self, mock_conn):
+        # Jumping by name should send the cue point name to the RS
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"name": "Verse"}
         mock_conn.return_value = mock_ableton
@@ -169,11 +177,12 @@ class TestJumpToCuePointCommand:
 
 
 class TestCreateCuePointCommand:
-    """T028: Test create/delete cue point commands."""
+    """Test create/delete cue point commands."""
 
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')
     def test_create_at_bar(self, mock_conn, mock_ts):
+        # Creating a cue point at bar 5 should convert to beat 16.0 and include the name
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {}
         mock_conn.return_value = mock_ableton
@@ -187,6 +196,7 @@ class TestCreateCuePointCommand:
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')
     def test_delete_at_bar(self, mock_conn, mock_ts):
+        # Deleting a cue point at bar 5 should convert to beat 16.0
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {}
         mock_conn.return_value = mock_ableton
@@ -199,11 +209,12 @@ class TestCreateCuePointCommand:
 
 
 class TestCreateArrangementMidiClipCommand:
-    """T038: Test create_arrangement_midi_clip command construction."""
+    """Test create_arrangement_midi_clip command construction."""
 
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')
     def test_bar_range_converts(self, mock_conn, mock_ts):
+        # Track 1 → 0, bars 5–9 → position 16.0, length 16.0
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "start_time": 16.0, "overlapped_clips": []}
@@ -222,6 +233,7 @@ class TestCreateArrangementMidiClipCommand:
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')
     def test_overlap_warning(self, mock_conn, mock_ts):
+        # When the RS reports overlapped clips, the result should contain a warning
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "start_time": 0.0, "overlapped_clips": ["Intro"]}
@@ -235,11 +247,12 @@ class TestCreateArrangementMidiClipCommand:
 
 
 class TestCreateArrangementAudioClipCommand:
-    """T038: Test create_arrangement_audio_clip command construction."""
+    """Test create_arrangement_audio_clip command construction."""
 
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')
     def test_converts_indices(self, mock_conn, mock_ts):
+        # Track 2 → 1 (0-based), file path passed through unchanged
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {}
         mock_conn.return_value = mock_ableton
@@ -254,11 +267,12 @@ class TestCreateArrangementAudioClipCommand:
 
 
 class TestDuplicateClipToArrangementCommand:
-    """T038: Test duplicate_clip_to_arrangement command construction."""
+    """Test duplicate_clip_to_arrangement command construction."""
 
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')
     def test_converts_all_indices(self, mock_conn, mock_ts):
+        # Both track and clip indices convert from 1-based to 0-based; bar converts to beat
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {}
         mock_conn.return_value = mock_ableton
@@ -274,10 +288,11 @@ class TestDuplicateClipToArrangementCommand:
 
 
 class TestDeleteArrangementClipCommand:
-    """T038: Test delete_arrangement_clip command construction."""
+    """Test delete_arrangement_clip command construction."""
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_by_index(self, mock_conn):
+        # Deleting by index: track 1 → 0, clip 2 → 1 (both 1-based to 0-based)
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"deleted": True}
         mock_conn.return_value = mock_ableton
@@ -291,6 +306,7 @@ class TestDeleteArrangementClipCommand:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_by_name(self, mock_conn):
+        # Deleting by name should pass clip_name and omit clip_index from the command
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"deleted": True}
         mock_conn.return_value = mock_ableton
@@ -305,10 +321,11 @@ class TestDeleteArrangementClipCommand:
 
 
 class TestSetArrangementClipPropertyCommand:
-    """T042: Test set_arrangement_clip_property command construction."""
+    """Test set_arrangement_clip_property command construction."""
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_index_conversion(self, mock_conn):
+        # Track 2 → 1, clip 3 → 2 when sending to the RS
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"property": "muted", "value": True}
         mock_conn.return_value = mock_ableton
@@ -323,6 +340,7 @@ class TestSetArrangementClipPropertyCommand:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_only_non_none_sent(self, mock_conn):
+        # Only properties with non-None values should generate RS commands
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"property": "muted", "value": True}
         mock_conn.return_value = mock_ableton
@@ -336,6 +354,7 @@ class TestSetArrangementClipPropertyCommand:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_multiple_props_sends_multiple(self, mock_conn):
+        # Setting two properties should result in two separate RS commands
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"property": "x", "value": True}
         mock_conn.return_value = mock_ableton
@@ -349,6 +368,7 @@ class TestSetArrangementClipPropertyCommand:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_no_props_no_command(self, mock_conn):
+        # When no properties are specified, no RS commands should be sent
         mock_ableton = MagicMock()
         mock_conn.return_value = mock_ableton
 
@@ -361,10 +381,11 @@ class TestSetArrangementClipPropertyCommand:
 
 
 class TestSetAbletonViewCommand:
-    """T048: Test set_ableton_view command construction."""
+    """Test set_ableton_view command construction."""
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_sends_view_name(self, mock_conn):
+        # The view name string should be passed through to the RS as view_name
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"visible": True}
         mock_conn.return_value = mock_ableton
@@ -377,10 +398,11 @@ class TestSetAbletonViewCommand:
 
 
 class TestControlArrangementViewCommand:
-    """T048: Test control_arrangement_view command construction."""
+    """Test control_arrangement_view command construction."""
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_collapse_converts_index(self, mock_conn):
+        # Track index 3 (1-based) should convert to 2 (0-based) for collapse action
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"action": "collapse_track", "done": True}
         mock_conn.return_value = mock_ableton
@@ -394,6 +416,7 @@ class TestControlArrangementViewCommand:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_zoom_in(self, mock_conn):
+        # Zoom actions that don't need a track index should default track_index to 0
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"action": "zoom_in", "done": True}
         mock_conn.return_value = mock_ableton
@@ -406,10 +429,11 @@ class TestControlArrangementViewCommand:
 
 
 class TestManageClipAutomationCommand:
-    """T052: Test manage_clip_automation command construction."""
+    """Test manage_clip_automation command construction."""
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_create_converts_indices(self, mock_conn):
+        # Track 2 → 1, clip 3 → 2; action and parameter_name pass through
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"action": "create", "done": True}
         mock_conn.return_value = mock_ableton
@@ -427,6 +451,7 @@ class TestManageClipAutomationCommand:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_clear_all(self, mock_conn):
+        # The clear_all action should produce a result message indicating all automation was cleared
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {"action": "clear_all", "done": True}
         mock_conn.return_value = mock_ableton

--- a/tests/unit/test_bar_beat_conversion.py
+++ b/tests/unit/test_bar_beat_conversion.py
@@ -16,80 +16,104 @@ from MCP_Server.server import bar_to_beat, beat_to_bar
 
 class TestBarToBeat:
     def test_4_4_bar_1(self):
+        # Bar 1 in 4/4 time starts at beat 0.0 (the very beginning)
         assert bar_to_beat(1, 4, 4) == 0.0
 
     def test_4_4_bar_2(self):
+        # Bar 2 in 4/4 time starts at beat 4.0 (one bar of 4 beats)
         assert bar_to_beat(2, 4, 4) == 4.0
 
     def test_4_4_bar_5(self):
+        # Bar 5 in 4/4 time starts at beat 16.0 (four bars × 4 beats)
         assert bar_to_beat(5, 4, 4) == 16.0
 
     def test_4_4_bar_17(self):
+        # Bar 17 in 4/4 time starts at beat 64.0 (sixteen bars × 4 beats)
         assert bar_to_beat(17, 4, 4) == 64.0
 
     def test_3_4_bar_1(self):
+        # Bar 1 in 3/4 time still starts at beat 0.0
         assert bar_to_beat(1, 3, 4) == 0.0
 
     def test_3_4_bar_5(self):
+        # Bar 5 in 3/4 time: 4 bars × 3 beats per bar = beat 12.0
         assert bar_to_beat(5, 3, 4) == 12.0
 
     def test_6_8_bar_1(self):
+        # Bar 1 in 6/8 time starts at beat 0.0
         assert bar_to_beat(1, 6, 8) == 0.0
 
     def test_6_8_bar_5(self):
+        # Bar 5 in 6/8 time: 4 bars × 3 beats per bar = beat 12.0
+        # (6 eighth notes = 3 quarter-note beats per bar)
         assert bar_to_beat(5, 6, 8) == 12.0
 
     def test_6_8_bar_9(self):
+        # Bar 9 in 6/8 time: 8 bars × 3 beats per bar = beat 24.0
         assert bar_to_beat(9, 6, 8) == 24.0
 
     def test_default_time_signature(self):
+        # When no time signature is given, defaults to 4/4; bar 3 = beat 8.0
         assert bar_to_beat(3) == 8.0
 
 
 class TestBeatToBar:
     def test_4_4_beat_0(self):
+        # Beat 0.0 in 4/4 time is bar 1 (1-based)
         assert beat_to_bar(0.0, 4, 4) == 1
 
     def test_4_4_beat_4(self):
+        # Beat 4.0 in 4/4 time is bar 2 (exactly one bar elapsed)
         assert beat_to_bar(4.0, 4, 4) == 2
 
     def test_4_4_beat_16(self):
+        # Beat 16.0 in 4/4 time is bar 5 (four complete bars)
         assert beat_to_bar(16.0, 4, 4) == 5
 
     def test_4_4_beat_64(self):
+        # Beat 64.0 in 4/4 time is bar 17 (sixteen complete bars)
         assert beat_to_bar(64.0, 4, 4) == 17
 
     def test_3_4_beat_0(self):
+        # Beat 0.0 in 3/4 time is bar 1
         assert beat_to_bar(0.0, 3, 4) == 1
 
     def test_3_4_beat_12(self):
+        # Beat 12.0 in 3/4 time is bar 5 (4 bars × 3 beats)
         assert beat_to_bar(12.0, 3, 4) == 5
 
     def test_6_8_beat_0(self):
+        # Beat 0.0 in 6/8 time is bar 1
         assert beat_to_bar(0.0, 6, 8) == 1
 
     def test_6_8_beat_12(self):
+        # Beat 12.0 in 6/8 time is bar 5
         assert beat_to_bar(12.0, 6, 8) == 5
 
     def test_mid_bar_rounds_down(self):
+        # A beat position mid-bar should round down to the current bar number
         assert beat_to_bar(2.5, 4, 4) == 1
 
     def test_default_time_signature(self):
+        # Defaults to 4/4; beat 8.0 should be bar 3
         assert beat_to_bar(8.0) == 3
 
 
 class TestRoundTrip:
     def test_4_4_round_trip(self):
+        # Converting bar→beat→bar in 4/4 should return the original bar
         for bar in range(1, 20):
             beat = bar_to_beat(bar, 4, 4)
             assert beat_to_bar(beat, 4, 4) == bar
 
     def test_3_4_round_trip(self):
+        # Converting bar→beat→bar in 3/4 should return the original bar
         for bar in range(1, 20):
             beat = bar_to_beat(bar, 3, 4)
             assert beat_to_bar(beat, 3, 4) == bar
 
     def test_6_8_round_trip(self):
+        # Converting bar→beat→bar in 6/8 should return the original bar
         for bar in range(1, 20):
             beat = bar_to_beat(bar, 6, 8)
             assert beat_to_bar(beat, 6, 8) == bar

--- a/tests/unit/test_core_indexing.py
+++ b/tests/unit/test_core_indexing.py
@@ -1,0 +1,79 @@
+"""Unit tests for the 1-based → 0-based index conversion helpers."""
+
+import sys
+import os
+from unittest.mock import MagicMock
+import pytest
+
+# Mock mcp dependencies before importing server module
+sys.modules['mcp'] = MagicMock()
+sys.modules['mcp.server'] = MagicMock()
+sys.modules['mcp.server.fastmcp'] = MagicMock()
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from MCP_Server.server import _to_zero_based, _optional_to_zero_based
+
+
+# ── _to_zero_based ──────────────────────────────────────────────
+
+
+class TestToZeroBased:
+    def test_converts_1_to_0(self):
+        # The smallest valid 1-based index should map to 0
+        assert _to_zero_based(1) == 0
+
+    def test_converts_5_to_4(self):
+        # A mid-range 1-based index subtracts one correctly
+        assert _to_zero_based(5) == 4
+
+    def test_converts_100_to_99(self):
+        # Large indices convert correctly without overflow issues
+        assert _to_zero_based(100) == 99
+
+    def test_rejects_zero(self):
+        # Zero is not a valid 1-based index and should raise ValueError
+        with pytest.raises(ValueError, match="must be >= 1"):
+            _to_zero_based(0)
+
+    def test_rejects_negative(self):
+        # Negative values are invalid 1-based indices
+        with pytest.raises(ValueError, match="must be >= 1"):
+            _to_zero_based(-1)
+
+    def test_error_includes_field_name(self):
+        # The error message should include the custom field name for debugging
+        with pytest.raises(ValueError, match="track_index"):
+            _to_zero_based(0, "track_index")
+
+    def test_default_field_name(self):
+        # When no field name is given, the error should use the default "index"
+        with pytest.raises(ValueError, match="index"):
+            _to_zero_based(0)
+
+
+# ── _optional_to_zero_based ─────────────────────────────────────
+
+
+class TestOptionalToZeroBased:
+    def test_zero_returns_none(self):
+        # Zero means "not specified" for optional indices, so it returns None
+        assert _optional_to_zero_based(0) is None
+
+    def test_converts_1_to_0(self):
+        # A provided optional index of 1 should convert to 0-based
+        assert _optional_to_zero_based(1) == 0
+
+    def test_converts_3_to_2(self):
+        # A mid-range optional index subtracts one correctly
+        assert _optional_to_zero_based(3) == 2
+
+    def test_rejects_negative(self):
+        # Negative values are never valid, even for optional indices
+        with pytest.raises(ValueError, match="must be >= 0"):
+            _optional_to_zero_based(-1)
+
+    def test_error_includes_field_name(self):
+        # The error message should include the custom field name for debugging
+        with pytest.raises(ValueError, match="chain_index"):
+            _optional_to_zero_based(-1, "chain_index")

--- a/tests/unit/test_device_commands.py
+++ b/tests/unit/test_device_commands.py
@@ -26,10 +26,11 @@ from MCP_Server.server import (
 
 
 class TestGetDeviceParameters:
-    """T011: Test get_device_parameters tool."""
+    """Test get_device_parameters tool."""
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_sends_correct_command(self, mock_conn):
+        # Track 1 → 0, device 2 → 1; verify the RS receives 0-based indices
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "device_name": "Wavetable",
@@ -58,6 +59,7 @@ class TestGetDeviceParameters:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_detail_mode_show_all(self, mock_conn):
+        # With show_all=True, the result should list individual parameter names and values
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "device_name": "Serum",
@@ -77,6 +79,7 @@ class TestGetDeviceParameters:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_chain_index_converted(self, mock_conn):
+        # Chain index 2 (1-based) should convert to 1 (0-based) before sending
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "device_name": "Test", "device_class": "Test",
@@ -90,10 +93,11 @@ class TestGetDeviceParameters:
 
 
 class TestSetDeviceParameter:
-    """T015: Test set_device_parameter tool."""
+    """Test set_device_parameter tool."""
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_sends_correct_command_by_name(self, mock_conn):
+        # Setting a parameter by name should resolve the name and send the correct value
         mock_ableton = MagicMock()
         # First call: get_device_parameters for alias resolution
         mock_ableton.send_command.side_effect = [
@@ -110,6 +114,7 @@ class TestSetDeviceParameter:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_sends_by_index(self, mock_conn):
+        # Setting a parameter by index should bypass alias resolution
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "parameter_name": "Volume", "old_value": 0.5,
@@ -122,6 +127,7 @@ class TestSetDeviceParameter:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_clamp_warning(self, mock_conn):
+        # When the RS clamps a value, the result should mention it was clamped
         mock_ableton = MagicMock()
         mock_ableton.send_command.side_effect = [
             {"device_name": "Test", "parameters": []},
@@ -136,6 +142,7 @@ class TestSetDeviceParameter:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_alias_resolution(self, mock_conn):
+        # A friendly alias like "wavetable position" should resolve to the real param name
         mock_ableton = MagicMock()
         mock_ableton.send_command.side_effect = [
             {"device_name": "Serum", "parameters": []},
@@ -153,10 +160,11 @@ class TestSetDeviceParameter:
 
 
 class TestEnableDisableDevice:
-    """T020: Test enable_device and disable_device tools."""
+    """Test enable_device and disable_device tools."""
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_enable_by_index(self, mock_conn):
+        # Enabling device 2 on track 1 should send enabled=True with 0-based indices
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "device_name": "Compressor", "is_active": True,
@@ -171,6 +179,7 @@ class TestEnableDisableDevice:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_disable_by_index(self, mock_conn):
+        # Disabling device 1 on track 1 should send enabled=False
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "device_name": "EQ Eight", "is_active": False,
@@ -184,6 +193,7 @@ class TestEnableDisableDevice:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_by_name_resolves(self, mock_conn):
+        # When device_name is given instead of device_index, resolve to the correct 0-based index
         mock_ableton = MagicMock()
         mock_ableton.send_command.side_effect = [
             {"devices": [{"index": 0, "name": "Compressor"}, {"index": 1, "name": "EQ Eight"}]},
@@ -197,6 +207,7 @@ class TestEnableDisableDevice:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_ambiguous_name_error(self, mock_conn):
+        # Multiple devices with the same name should produce an error instead of guessing
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "devices": [{"index": 0, "name": "EQ Eight"}, {"index": 1, "name": "EQ Eight"}],
@@ -208,10 +219,11 @@ class TestEnableDisableDevice:
 
 
 class TestGetChainInfo:
-    """T026: Test get_chain_info and get_drum_pad_info."""
+    """Test get_chain_info and get_drum_pad_info."""
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_list_chains(self, mock_conn):
+        # Listing chains should show chain count, names, and devices inside each chain
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "device_name": "Instrument Rack",
@@ -232,6 +244,7 @@ class TestGetChainInfo:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_not_a_rack_error(self, mock_conn):
+        # Requesting chain info on a non-rack device should return an error message
         mock_ableton = MagicMock()
         mock_ableton.send_command.side_effect = Exception("Device 'Serum' is not a rack")
         mock_conn.return_value = mock_ableton
@@ -241,6 +254,7 @@ class TestGetChainInfo:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_drum_pad_info(self, mock_conn):
+        # Drum pad info should list filled pads with their note numbers, names, and devices
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "device_name": "Drum Rack",
@@ -258,10 +272,11 @@ class TestGetChainInfo:
 
 
 class TestDeleteDevice:
-    """T030: Test delete_device tool."""
+    """Test delete_device tool."""
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_delete_by_index(self, mock_conn):
+        # Track 1 → 0, device 2 → 1; verify the correct 0-based indices are sent
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "deleted_device": "Compressor", "remaining_devices": 1,
@@ -277,6 +292,7 @@ class TestDeleteDevice:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_delete_by_name(self, mock_conn):
+        # When deleting by name, resolve the device name to its 0-based index first
         mock_ableton = MagicMock()
         mock_ableton.send_command.side_effect = [
             {"devices": [{"index": 0, "name": "EQ Eight"}, {"index": 1, "name": "Limiter"}]},
@@ -290,10 +306,11 @@ class TestDeleteDevice:
 
 
 class TestNavigateDevicePreset:
-    """T034: Test navigate_device_preset tool."""
+    """Test navigate_device_preset tool."""
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_next_preset(self, mock_conn):
+        # Navigating to next preset should send 0-based indices and direction="next"
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "device_name": "Serum", "preset_name": "Warm Pad",
@@ -310,6 +327,7 @@ class TestNavigateDevicePreset:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_current_preset(self, mock_conn):
+        # Direction "current" should report the active preset without changing it
         mock_ableton = MagicMock()
         mock_ableton.send_command.return_value = {
             "device_name": "Serum", "preset_name": "Init",
@@ -323,6 +341,7 @@ class TestNavigateDevicePreset:
 
     @patch('MCP_Server.server.get_ableton_connection')
     def test_no_presets_error(self, mock_conn):
+        # When a device has no presets, the error should be reported gracefully
         mock_ableton = MagicMock()
         mock_ableton.send_command.side_effect = Exception("Device has no presets")
         mock_conn.return_value = mock_ableton

--- a/tests/unit/test_parameter_normalization.py
+++ b/tests/unit/test_parameter_normalization.py
@@ -20,33 +20,40 @@ class TestNormalizeParam:
     """Tests for normalize_param()."""
 
     def test_midpoint(self):
+        # The midpoint of a 0–100 range should normalize to 0.5
         assert normalize_param(50.0, 0.0, 100.0) == 0.5
 
     def test_minimum_returns_zero(self):
+        # A value at the minimum of its range normalizes to 0.0
         assert normalize_param(0.0, 0.0, 100.0) == 0.0
 
     def test_maximum_returns_one(self):
+        # A value at the maximum of its range normalizes to 1.0
         assert normalize_param(100.0, 0.0, 100.0) == 1.0
 
     def test_negative_range(self):
+        # Normalization works correctly with negative min/max values
         assert normalize_param(-6.0, -12.0, 0.0) == 0.5
 
     def test_clamp_above_max(self):
+        # Values exceeding the max should be clamped to 1.0
         assert normalize_param(150.0, 0.0, 100.0) == 1.0
 
     def test_clamp_below_min(self):
+        # Values below the min should be clamped to 0.0
         assert normalize_param(-10.0, 0.0, 100.0) == 0.0
 
     def test_min_equals_max_returns_zero(self):
-        """Division by zero edge case."""
+        """Division by zero edge case: when min == max, return 0.0."""
         assert normalize_param(5.0, 5.0, 5.0) == 0.0
 
     def test_small_range(self):
+        # Normalization remains accurate with very small ranges
         result = normalize_param(0.5, 0.0, 1.0)
         assert abs(result - 0.5) < 1e-9
 
     def test_already_normalized_range(self):
-        """When min=0, max=1, value should pass through."""
+        """When min=0 and max=1, the value should pass through unchanged."""
         assert normalize_param(0.75, 0.0, 1.0) == 0.75
 
 
@@ -54,33 +61,38 @@ class TestDenormalizeParam:
     """Tests for denormalize_param()."""
 
     def test_midpoint(self):
+        # Normalized 0.5 in a 0–100 range should denormalize to 50.0
         assert denormalize_param(0.5, 0.0, 100.0) == 50.0
 
     def test_zero_returns_min(self):
+        # Normalized 0.0 should map back to the minimum of the range
         assert denormalize_param(0.0, 0.0, 100.0) == 0.0
 
     def test_one_returns_max(self):
+        # Normalized 1.0 should map back to the maximum of the range
         assert denormalize_param(1.0, 0.0, 100.0) == 100.0
 
     def test_negative_range(self):
+        # Denormalization works correctly with negative min/max values
         assert denormalize_param(0.5, -12.0, 0.0) == -6.0
 
     def test_clamp_above_one(self):
-        """Values above 1.0 should clamp to max."""
+        """Normalized values above 1.0 should clamp to the max of the range."""
         assert denormalize_param(1.5, 0.0, 100.0) == 100.0
 
     def test_clamp_below_zero(self):
-        """Values below 0.0 should clamp to min."""
+        """Normalized values below 0.0 should clamp to the min of the range."""
         assert denormalize_param(-0.5, 0.0, 100.0) == 0.0
 
     def test_roundtrip(self):
-        """normalize then denormalize should return original value."""
+        """Normalizing then denormalizing should return the original value."""
         original = 42.0
         normalized = normalize_param(original, 0.0, 100.0)
         result = denormalize_param(normalized, 0.0, 100.0)
         assert abs(result - original) < 1e-9
 
     def test_roundtrip_negative_range(self):
+        # Round-trip accuracy holds for negative parameter ranges too
         original = -3.0
         normalized = normalize_param(original, -12.0, 0.0)
         result = denormalize_param(normalized, -12.0, 0.0)

--- a/tests/unit/test_plugin_aliases.py
+++ b/tests/unit/test_plugin_aliases.py
@@ -16,70 +16,82 @@ class TestResolveAlias:
     """Test resolve_alias function."""
 
     def test_known_alias_serum(self):
+        # A known friendly alias for Serum should resolve to the real parameter name
         result = resolve_alias("Serum", "wavetable position")
         assert result == "Osc A WT Pos"
 
     def test_case_insensitive(self):
+        # Alias lookup should be case-insensitive for user convenience
         result = resolve_alias("Serum", "Wavetable Position")
         assert result == "Osc A WT Pos"
 
     def test_unknown_alias_returns_none(self):
+        # An alias that doesn't exist for the given plugin should return None
         result = resolve_alias("Serum", "nonexistent parameter")
         assert result is None
 
     def test_unknown_plugin_returns_none(self):
+        # An unrecognized plugin name should return None even with a valid alias
         result = resolve_alias("SomeUnknownPlugin", "filter cutoff")
         assert result is None
 
     def test_real_name_not_resolved_as_alias(self):
-        """Direct parameter names should NOT match aliases."""
+        """Direct parameter names should NOT match as aliases — they are used as-is."""
         result = resolve_alias("Serum", "Osc A WT Pos")
         # "Osc A WT Pos" is a real name, not a friendly alias
         assert result is None
 
     def test_filter_cutoff(self):
+        # The "filter cutoff" alias should resolve to Serum's internal parameter name
         result = resolve_alias("Serum", "filter cutoff")
         assert result == "Fil Cutoff"
 
     def test_macro(self):
+        # Macro aliases should resolve correctly for Serum
         result = resolve_alias("Serum", "macro 1")
         assert result == "Macro 1"
 
     def test_device_name_contains_match(self):
-        """Device name may contain extra text like 'Serum FX'."""
+        # Device names with extra text (e.g. "Serum FX") should still match "Serum" aliases
         result = resolve_alias("Serum FX", "filter cutoff")
         assert result == "Fil Cutoff"
 
 
 class TestGetAliasForParam:
-    """Test reverse alias lookup."""
+    """Test reverse alias lookup (real parameter name → friendly alias)."""
 
     def test_known_param(self):
+        # A known real parameter name should return its friendly alias
         result = get_alias_for_param("Serum", "Osc A WT Pos")
         assert result == "wavetable position"
 
     def test_unknown_param(self):
+        # A parameter name with no alias mapping should return None
         result = get_alias_for_param("Serum", "SomeRandomParam")
         assert result is None
 
     def test_unknown_plugin(self):
+        # An unrecognized plugin should return None for any parameter
         result = get_alias_for_param("UnknownPlugin", "Osc A WT Pos")
         assert result is None
 
 
 class TestGetCategories:
-    """Test category retrieval."""
+    """Test category retrieval for parameter grouping."""
 
     def test_serum_has_categories(self):
+        # Serum should have well-known categories like Oscillator A and Filter
         cats = get_categories("Serum")
         assert cats is not None
         assert "Oscillator A" in cats
         assert "Filter" in cats
 
     def test_unknown_plugin_returns_none(self):
+        # An unrecognized plugin should return None (no categories available)
         cats = get_categories("UnknownPlugin")
         assert cats is None
 
     def test_categories_have_prefixes(self):
+        # Each category should contain parameter name prefixes for grouping
         cats = get_categories("Serum")
         assert "Osc A" in cats["Oscillator A"]


### PR DESCRIPTION
### This PR standardizes indexing behaviour across all MCP tools by enforcing consistent conversion from 1-based (agent-facing) to 0-based (Remote Script).

### Problem

Indexing behaviour was previously inconsistent and error-prone:

* Nine session-view tools (`get_track_info`, `set_track_name`, `create_clip`, `add_notes_to_clip`, `set_clip_name`, `fire_clip`, `stop_clip`, `load_instrument_or_effect`, `load_drum_kit`) passed raw indices directly to the Remote Script.
* All other tools correctly converted from 1-based to 0-based indexing.

This inconsistency caused off-by-one errors when agents assumed a uniform 1-based interface, impacting track and clip referencing.

### Solution

* Introduced shared helper functions:

  * `_to_zero_based`
  * `_optional_to_zero_based`
* Applied these helpers uniformly across all 25 MCP tools to ensure consistent indexing behavior.

### Testing

* Validated changes through both manual testing and automated tests.
* Added unit tests for the helper functions.
* Improved test readability with explanatory comments across all test files.

### Result

* Eliminates off-by-one errors across MCP tools.
* Provides a consistent 1-based interface for agents.
* Improves speed, reduces the number of required MCP calls in practice.