### PR TITLE
feat: limit/offset pagination for get_browser_items_at_path

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -439,7 +439,9 @@ class AbletonMCP(ControlSurface):
                 response["result"] = self.get_browser_tree(category_type)
             elif command_type == "get_browser_items_at_path":
                 path = params.get("path", "")
-                response["result"] = self.get_browser_items_at_path(path)
+                limit = params.get("limit")  # None = unlimited (backward compat)
+                offset = params.get("offset", 0)
+                response["result"] = self.get_browser_items_at_path(path, limit=limit, offset=offset)
             elif command_type == "get_arrangement_info":
                 track_index = params.get("track_index", -1)
                 response["result"] = self._get_arrangement_info(track_index)
@@ -1956,17 +1958,22 @@ class AbletonMCP(ControlSurface):
             self.log_message(traceback.format_exc())
             raise
     
-    def get_browser_items_at_path(self, path):
+    def get_browser_items_at_path(self, path, limit=None, offset=0):
         """
         Get browser items at a specific path.
-        
+
         Args:
             path: Path in the format "category/folder/subfolder"
                  where category is one of: instruments, sounds, drums, audio_effects, midi_effects
                  or any other available browser category
-                 
+            limit: Maximum number of items to return (None = all). Prevents
+                   large folders (e.g. sample packs with 500+ items) from
+                   flooding the response.
+            offset: Number of items to skip from the start (for pagination).
+
         Returns:
-            Dictionary with items at the specified path
+            Dictionary with items at the specified path. Includes
+            `total_count` (items before slicing) and `returned` (after).
         """
         try:
             # Access the application's browser instance instead of creating a new one
@@ -2062,7 +2069,25 @@ class AbletonMCP(ControlSurface):
                         "uri": child.uri if hasattr(child, 'uri') else None
                     }
                     items.append(item_info)
-            
+
+            # Apply pagination (offset + limit). Negative/invalid values are
+            # clamped silently so the Remote Script never crashes on a bad
+            # caller; the MCP-server wrapper is where validation errors
+            # should surface.
+            total_count = len(items)
+            try:
+                off = max(0, int(offset or 0))
+            except (TypeError, ValueError):
+                off = 0
+            if limit is None:
+                sliced = items[off:]
+            else:
+                try:
+                    lim = max(0, int(limit))
+                except (TypeError, ValueError):
+                    lim = 0
+                sliced = items[off:off + lim]
+
             result = {
                 "path": path,
                 "name": current_item.name if hasattr(current_item, 'name') else "Unknown",
@@ -2070,10 +2095,15 @@ class AbletonMCP(ControlSurface):
                 "is_folder": hasattr(current_item, 'children') and bool(current_item.children),
                 "is_device": hasattr(current_item, 'is_device') and current_item.is_device,
                 "is_loadable": hasattr(current_item, 'is_loadable') and current_item.is_loadable,
-                "items": items
+                "items": sliced,
+                "total_count": total_count,
+                "returned": len(sliced),
+                "offset": off,
+                "limit": limit
             }
-            
-            self.log_message("Retrieved {0} items at path: {1}".format(len(items), path))
+
+            self.log_message("Retrieved {0}/{1} items at path: {2} (offset={3}, limit={4})".format(
+                len(sliced), total_count, path, off, limit))
             return result
             
         except Exception as e:

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -777,27 +777,40 @@ def get_browser_tree(ctx: Context, category_type: str = "all") -> str:
             return f"Error getting browser tree: {error_msg}"
 
 @mcp.tool()
-def get_browser_items_at_path(ctx: Context, path: str) -> str:
+def get_browser_items_at_path(ctx: Context, path: str, limit: int = 50, offset: int = 0) -> str:
     """
     Get browser items at a specific path in Ableton's browser.
-    
+
     Parameters:
     - path: Path in the format "category/folder/subfolder"
             where category is one of the available browser categories in Ableton
+    - limit: Max items to return (default 50). Large sample folders can hold
+             500+ items — the default caps the response to keep tool-call
+             output tight. Set to 0 for all items.
+    - offset: Number of items to skip (for pagination). Default 0.
+
+    Response is JSON including 'items', 'total_count', 'returned', 'offset',
+    and 'limit'. If total_count > offset + returned, call again with
+    offset = offset + returned to get the next page.
     """
     try:
         ableton = get_ableton_connection()
-        result = ableton.send_command("get_browser_items_at_path", {
-            "path": path
-        })
-        
+        # Coerce defensively — MCP callers sometimes send numeric args as strings
+        lim = int(limit) if limit is not None else 0
+        off = int(offset) if offset is not None else 0
+        # limit=0 → unlimited (omit from payload, Remote Script treats None as unlimited)
+        payload = {"path": path, "offset": off}
+        if lim > 0:
+            payload["limit"] = lim
+        result = ableton.send_command("get_browser_items_at_path", payload)
+
         # Check if there was an error with available categories
         if "error" in result and "available_categories" in result:
             error = result.get("error", "")
             available_cats = result.get("available_categories", [])
             return (f"Error: {error}\n"
                    f"Available browser categories: {', '.join(available_cats)}")
-        
+
         return json.dumps(result, indent=2)
     except Exception as e:
         error_msg = str(e)

--- a/tests/unit/test_browser_pagination.py
+++ b/tests/unit/test_browser_pagination.py
@@ -1,0 +1,140 @@
+"""Unit tests for get_browser_items_at_path limit/offset pagination.
+
+Covers both halves:
+- The MCP-server wrapper builds the correct payload (limit omitted when 0,
+  offset always sent, IntParam strings coerced to ints).
+- Response formatting passes through total_count / returned from the Remote
+  Script so the LLM can page.
+"""
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# Mock MCP dependencies before importing server
+_mock_mcp_module = MagicMock()
+_mock_fastmcp = MagicMock()
+_mock_fastmcp.FastMCP.return_value.tool.return_value = lambda fn: fn
+sys.modules['mcp'] = _mock_mcp_module
+sys.modules['mcp.server'] = MagicMock()
+sys.modules['mcp.server.fastmcp'] = _mock_fastmcp
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from MCP_Server.server import get_browser_items_at_path  # noqa: E402
+
+
+def _fake_response(items, total=None, returned=None, offset=0, limit=None):
+    return {
+        "path": "drums/acoustic",
+        "name": "acoustic",
+        "uri": "view:drums#acoustic",
+        "is_folder": True,
+        "is_device": False,
+        "is_loadable": False,
+        "items": items,
+        "total_count": total if total is not None else len(items),
+        "returned": returned if returned is not None else len(items),
+        "offset": offset,
+        "limit": limit,
+    }
+
+
+class TestPayload:
+    """The wrapper must build the right payload for the Remote Script."""
+
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_default_limit_50_is_sent(self, mock_conn):
+        # Default (no explicit limit) should send limit=50 to RS
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = _fake_response([])
+        mock_conn.return_value = mock_ableton
+
+        get_browser_items_at_path(MagicMock(), path="drums/acoustic")
+
+        mock_ableton.send_command.assert_called_with(
+            "get_browser_items_at_path",
+            {"path": "drums/acoustic", "offset": 0, "limit": 50},
+        )
+
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_limit_zero_omits_limit(self, mock_conn):
+        # limit=0 means "all items" → payload must NOT include limit,
+        # so the Remote Script defaults to unlimited slicing
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = _fake_response([])
+        mock_conn.return_value = mock_ableton
+
+        get_browser_items_at_path(MagicMock(), path="drums/", limit="0")
+
+        mock_ableton.send_command.assert_called_with(
+            "get_browser_items_at_path",
+            {"path": "drums/", "offset": 0},
+        )
+
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_string_params_coerced(self, mock_conn):
+        # IntParam is typed as str (Cowork compat); _i must coerce to int
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = _fake_response([])
+        mock_conn.return_value = mock_ableton
+
+        get_browser_items_at_path(MagicMock(), path="x", limit="25", offset="100")
+
+        mock_ableton.send_command.assert_called_with(
+            "get_browser_items_at_path",
+            {"path": "x", "offset": 100, "limit": 25},
+        )
+
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_custom_limit_and_offset(self, mock_conn):
+        # Pagination: page 2 of size 25 → offset=25, limit=25
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = _fake_response([])
+        mock_conn.return_value = mock_ableton
+
+        get_browser_items_at_path(MagicMock(), path="x", limit=25, offset=25)
+
+        mock_ableton.send_command.assert_called_with(
+            "get_browser_items_at_path",
+            {"path": "x", "offset": 25, "limit": 25},
+        )
+
+
+class TestResponsePassthrough:
+    """Response must expose total_count / returned so the LLM can page."""
+
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_pagination_metadata_in_json(self, mock_conn):
+        mock_ableton = MagicMock()
+        items = [{"name": f"kit_{i}", "uri": f"u{i}"} for i in range(50)]
+        mock_ableton.send_command.return_value = _fake_response(
+            items, total=500, returned=50, offset=0, limit=50
+        )
+        mock_conn.return_value = mock_ableton
+
+        result = get_browser_items_at_path(MagicMock(), path="drums/acoustic")
+        parsed = json.loads(result)
+
+        assert parsed["total_count"] == 500
+        assert parsed["returned"] == 50
+        assert parsed["offset"] == 0
+        assert parsed["limit"] == 50
+        assert len(parsed["items"]) == 50
+
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_error_response_still_surfaces(self, mock_conn):
+        # When the RS returns available_categories (bad path), we still need
+        # the friendly error message — pagination changes must not mask that
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = {
+            "path": "wrongcat",
+            "error": "Unknown or unavailable category: wrongcat",
+            "available_categories": ["instruments", "drums"],
+            "items": [],
+        }
+        mock_conn.return_value = mock_ableton
+
+        result = get_browser_items_at_path(MagicMock(), path="wrongcat")
+        assert "Unknown or unavailable category" in result
+        assert "instruments" in result


### PR DESCRIPTION
## Summary

Adds pagination (`limit` + `offset`) to `get_browser_items_at_path`. Large browser folders — e.g. sample packs with 500+ items — previously flooded the MCP response with ~50 KB of raw text per call, which is wasteful for LLM tool use and can hit context limits on long sessions.

- **Remote Script:** `get_browser_items_at_path(path, limit=None, offset=0)` slices the children list and returns `total_count`, `returned`, `offset`, `limit` so callers can page without guessing the folder size first.
- **MCP tool wrapper:** default `limit=50` (sane bound for typical LLM use); `limit=0` means unlimited (payload omits the key so old Remote Scripts still work).
- **Tests:** 6 new unit tests covering payload construction, string coercion, and response passthrough. Full suite (119 tests) remains green.

## Backward compatibility

Fully preserved in both directions:
- **Old MCP server + new Remote Script:** offset defaults to 0, missing `limit` means unlimited — identical behavior to current.
- **New MCP server + old Remote Script:** old RS ignores unknown params and returns all items; wrapper still passes them through.

Verified in a live Ableton 12 session: hot-reload of the new Remote Script, then `get_browser_items_at_path(path="drums")` via the (unchanged) old wrapper still returns all 145 drum kits as before.

## Test plan

- [x] `pytest tests/` — 119 passed, including 6 new pagination tests
- [x] Live hot-reload test in Ableton 12 — Remote Script loads cleanly, backward-compatible call path returns expected items
- [ ] Reviewer: spot-check that `limit=50` default feels right, or suggest a different default
- [ ] Reviewer: confirm the response-format change (new fields) won't break any downstream tooling you're aware of