### PR TITLE
Fix get_device_parameters / set_device_parameter import error

### DIFF
--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -1,4 +1,9 @@
-# ableton_mcp_server.py
+import os
+import sys
+
+if __package__ in (None, ""):
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from mcp.server.fastmcp import FastMCP, Context
 import socket
 import json
@@ -9,6 +14,12 @@ import time
 from dataclasses import dataclass
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Dict, Any, List, Union
+
+from MCP_Server.plugin_aliases import (
+    get_alias_for_param,
+    get_categories,
+    resolve_alias,
+)
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, 
@@ -1694,8 +1705,6 @@ def get_device_parameters(
     Specify category or show_all=True for full parameter details.
     """
     try:
-        from MCP_Server.plugin_aliases import get_categories, get_alias_for_param
-
         ableton = get_ableton_connection()
         ti = _to_zero_based(track_index, "track_index")
         di = _to_zero_based(device_index, "device_index")
@@ -1784,8 +1793,6 @@ def set_device_parameter(
     - value: Normalized value 0.0-1.0.
     """
     try:
-        from MCP_Server.plugin_aliases import resolve_alias
-
         ableton = get_ableton_connection()
         ti = _to_zero_based(track_index, "track_index")
         di = _to_zero_based(device_index, "device_index")

--- a/tests/unit/test_script_mode_imports.py
+++ b/tests/unit/test_script_mode_imports.py
@@ -1,0 +1,95 @@
+"""Regression: server.py must work when launched as `python /path/to/server.py`.
+
+Claude Desktop's MCP launcher invokes the server by absolute script path, which
+puts only the script's directory on sys.path — the parent `MCP_Server` package
+is not importable that way, so any `from MCP_Server.X import Y` inside a tool
+handler must be resilient to that layout.
+"""
+import os
+import subprocess
+import sys
+import textwrap
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+PKG_DIR = os.path.join(REPO_ROOT, "MCP_Server")
+SERVER_PATH = os.path.join(PKG_DIR, "server.py")
+
+
+def _run_in_script_mode(snippet: str) -> subprocess.CompletedProcess:
+    bootstrap = textwrap.dedent(
+        f"""
+        import sys
+        from unittest.mock import MagicMock
+        sys.modules['mcp'] = MagicMock()
+        sys.modules['mcp.server'] = MagicMock()
+        fastmcp = MagicMock()
+        fastmcp.FastMCP.return_value.tool.return_value = lambda fn: fn
+        sys.modules['mcp.server.fastmcp'] = fastmcp
+
+        sys.path = [p for p in sys.path if p not in ('', {REPO_ROOT!r})]
+        sys.path.insert(0, {PKG_DIR!r})
+
+        import importlib.util
+        spec = importlib.util.spec_from_file_location('server', {SERVER_PATH!r})
+        server = importlib.util.module_from_spec(spec)
+        sys.modules['server'] = server
+        spec.loader.exec_module(server)
+        """
+    )
+    return subprocess.run(
+        [sys.executable, "-c", bootstrap + "\n" + snippet],
+        capture_output=True,
+        text=True,
+        cwd="/",
+    )
+
+
+def test_get_device_parameters_does_not_crash_on_lazy_import():
+    snippet = textwrap.dedent(
+        """
+        from unittest.mock import MagicMock
+        ableton = MagicMock()
+        ableton.send_command.return_value = {
+            'device_name': 'Pro-Q 3',
+            'device_class': 'PluginDevice',
+            'parameter_count': 1,
+            'parameters': [{
+                'index': 0, 'name': 'Output Gain', 'value': 0.5,
+                'min': 0.0, 'max': 1.0, 'display_value': '0 dB',
+                'is_enabled': True, 'is_quantized': False, 'value_items': [],
+            }],
+        }
+        server.get_ableton_connection = lambda: ableton
+        out = server.get_device_parameters(MagicMock(), track_index=2, device_index=2)
+        print(out)
+        """
+    )
+    proc = _run_in_script_mode(snippet)
+    assert proc.returncode == 0, proc.stderr
+    assert "No module named" not in proc.stdout, proc.stdout
+    assert "Pro-Q 3" in proc.stdout
+
+
+def test_set_device_parameter_does_not_crash_on_lazy_import():
+    snippet = textwrap.dedent(
+        """
+        from unittest.mock import MagicMock
+        ableton = MagicMock()
+        ableton.send_command.side_effect = [
+            {'device_name': 'Pro-Q 3'},
+            {'parameter_name': 'Output Gain', 'display_value': '0 dB',
+             'new_value': 0.5, 'clamped': False},
+        ]
+        server.get_ableton_connection = lambda: ableton
+        out = server.set_device_parameter(
+            MagicMock(), track_index=2, device_index=2,
+            parameter_name='Output Gain', value=0.5,
+        )
+        print(out)
+        """
+    )
+    proc = _run_in_script_mode(snippet)
+    assert proc.returncode == 0, proc.stderr
+    assert "No module named" not in proc.stdout, proc.stdout
+    assert "Output Gain" in proc.stdout


### PR DESCRIPTION
Both device-parameter tools crash on every call with `Error getting device parameters: No module named 'MCP_Server'` when the server is started the way the README tells you to — `python /path/to/MCP_Server/server.py`. In that mode Python only puts the script's directory on `sys.path`, and the lazy `from MCP_Server.plugin_aliases import …` calls inside the two tools can't find the parent package.

The fix is a four-line shim at the top of `server.py` that prepends the project root to `sys.path` when there's no package context, plus hoisting the formerly-lazy imports to module level. That single canonical import form now works whether you launch `python server.py` (README config), `python -m MCP_Server.server`, or import it from the test suite.

Added `tests/unit/test_script_mode_imports.py`, which spawns a subprocess emulating the script-mode launch and asserts both tools return without an ImportError. `pytest tests/` → 138 passed.

Validated end-to-end against running Live 11 after restart: `get_device_parameters` and `set_device_parameter` both succeed against a real Pro-Q 3 / Scaler 3 chain.

Two files touched, ~100 lines net (most of it the new regression test).