### PR TITLE
Fix README Mac install path for Remote Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ pip install -e .
 ```
 
 ### 2. **Install Ableton Script**
-1. Find your Ableton Remote Scripts folder:
+1. Find your Ableton User Library Remote Scripts folder:
    - **Windows**: `C:\Users\[You]\Documents\Ableton\User Library\Remote Scripts\`
-   - **Mac**: `~/Library/Preferences/Ableton/Live [Version]/User Remote Scripts/`
+   - **Mac**: `~/Music/Ableton/User Library/Remote Scripts/`
 2. Create folder: `AbletonMCP`
 3. Copy `AbletonMCP_Remote_Script/__init__.py` into this folder
 


### PR DESCRIPTION
The README's macOS install path for third-party Remote Scripts points at `~/Library/Preferences/Ableton/Live [Version]/User Remote Scripts/`, which is a per-version preferences directory that doesn't survive Live upgrades. Ableton's User Library — `~/Music/Ableton/User Library/Remote Scripts/` — has been the supported location for user-installed Remote Scripts since Live 10.1.13, and it's already what the Windows line in the same list points at. Mac now matches.

*BTW*: I'm fixing all the bugs I can find that stem from using Ableton Live 11.3.43 Suite (most recent v11) since I haven't upgraded to 12. There's around 9 other bugs I'll patch in my fork so if you'd like me to submit the remaining fixes let me know in the comments below. I'm manually verifying each one and being careful to only add what's needed.