### PR TITLE
Fix cue point create/delete on Live 11 (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ Thumbs.db
 
 # Claude Code local settings (machine-specific)
 .claude/settings.local.json
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ Thumbs.db
 *.adv
 *.asd
 !AbletonMCP_Remote_Script/*
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ Thumbs.db
 *.asd
 !AbletonMCP_Remote_Script/*
 .envrc
+
+# Claude Code local settings (machine-specific)
+.claude/settings.local.json

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -1265,9 +1265,8 @@ class AbletonMCP(ControlSurface):
     def _create_cue_point(self, time, name=""):
         """Create a cue point at the given time.
 
-        On Live versions where ``CuePoint.name`` is read-only the
-        rename is logged and skipped; the locator keeps Live's
-        auto-generated name.
+        If ``name`` is provided, the locator is renamed after creation;
+        rename failures are logged.
         """
         try:
             for cp in tuple(self._song.cue_points):
@@ -1285,15 +1284,12 @@ class AbletonMCP(ControlSurface):
                                     cp.name = name
                                 except (AttributeError, RuntimeError) as e:
                                     self.log_message(
-                                        "CuePoint.name write rejected by Live: " + str(e))
+                                        "CuePoint.name assignment failed: " + str(e))
                                 break
                 except Exception as e:
                     self.log_message("Error finalizing cue point: " + str(e))
 
-            try:
-                self.schedule_message(1, _finalize)
-            except Exception:
-                _finalize()
+            self.schedule_message(1, _finalize)
             return {"time": time, "name": name}
         except Exception as e:
             self.log_message("Error creating cue point: " + str(e))
@@ -1317,10 +1313,7 @@ class AbletonMCP(ControlSurface):
                 except Exception as e:
                     self.log_message("Error finalizing cue delete: " + str(e))
 
-            try:
-                self.schedule_message(1, _finalize)
-            except Exception:
-                _finalize()
+            self.schedule_message(1, _finalize)
             return {"deleted": True}
         except Exception as e:
             self.log_message("Error deleting cue point: " + str(e))

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -317,7 +317,8 @@ class AbletonMCP(ControlSurface):
                             ti = params.get("track_index", 0)
                             pos = params.get("position", 0.0)
                             length = params.get("length", 4.0)
-                            result = self._create_arrangement_clip(ti, pos, length)
+                            name = params.get("name", "")
+                            result = self._create_arrangement_clip(ti, pos, length, name=name)
                         elif command_type == "create_arrangement_audio_clip":
                             ti = params.get("track_index", 0)
                             pos = params.get("position", 0.0)
@@ -613,14 +614,17 @@ class AbletonMCP(ControlSurface):
                     "type": self._get_device_type(device)
                 })
             
+            is_group = bool(getattr(track, "is_foldable", False))
+
             result = {
                 "index": track_index,
                 "name": track.name,
                 "is_audio_track": track.has_audio_input,
                 "is_midi_track": track.has_midi_input,
+                "is_group_track": is_group,
                 "mute": track.mute,
                 "solo": track.solo,
-                "arm": track.arm,
+                "arm": None if is_group else track.arm,
                 "volume": track.mixer_device.volume.value,
                 "panning": track.mixer_device.panning.value,
                 "clip_slots": clip_slots,
@@ -1174,17 +1178,23 @@ class AbletonMCP(ControlSurface):
                 tracks = [(track_index, self._song.tracks[track_index])]
 
             for idx, track in tracks:
+                is_group = bool(getattr(track, "is_foldable", False))
+                if is_group and track_index == -1:
+                    continue
+
                 clips = []
-                for ci, clip in enumerate(track.arrangement_clips):
-                    clip_info = self._get_arrangement_clip_info(clip)
-                    clip_info["index"] = ci
-                    clips.append(clip_info)
+                if not is_group:
+                    for ci, clip in enumerate(track.arrangement_clips):
+                        clip_info = self._get_arrangement_clip_info(clip)
+                        clip_info["index"] = ci
+                        clips.append(clip_info)
 
                 tracks_data.append({
                     "index": idx,
                     "name": track.name,
                     "is_midi": track.has_midi_input,
                     "is_audio": track.has_audio_input,
+                    "is_group_track": is_group,
                     "arrangement_clips": clips,
                     "clip_count": len(clips),
                 })
@@ -1255,12 +1265,16 @@ class AbletonMCP(ControlSurface):
     def _create_cue_point(self, time, name=""):
         """Create a cue point at the given time."""
         try:
-            # Check if cue already exists at this position
-            for cp in self._song.cue_points:
+            for cp in tuple(self._song.cue_points):
                 if abs(cp.time - time) < 0.01:
                     raise ValueError("Cue point already exists at this position: " + cp.name)
             self._song.current_song_time = time
             self._song.set_or_delete_cue()
+            if name:
+                for cp in tuple(self._song.cue_points):
+                    if abs(cp.time - time) < 0.01:
+                        cp.name = name
+                        break
             return {"time": time, "name": name}
         except Exception as e:
             self.log_message("Error creating cue point: " + str(e))
@@ -1295,26 +1309,62 @@ class AbletonMCP(ControlSurface):
         if track == self._song.master_track:
             raise ValueError("Cannot create arrangement clips on master track")
 
-    def _create_arrangement_clip(self, track_index, position, length):
-        """Create MIDI clip in arrangement."""
+    def _create_arrangement_clip(self, track_index, position, length, name=""):
+        """Create MIDI clip in arrangement.
+
+        Live 12 exposes Track.create_midi_clip(start_time, length) directly.
+        Live 11 has no such method, so round-trip through a session slot:
+        create_clip -> duplicate_clip_to_arrangement -> delete the session clip.
+        """
         try:
             if track_index < 0 or track_index >= len(self._song.tracks):
                 raise IndexError("Track index out of range")
             self._validate_not_return_or_master(track_index)
             track = self._song.tracks[track_index]
             overlapped = self._check_overlap(track, position, length)
-            track.create_midi_clip(position, length)
-            # Find the newly created clip
-            result = {"start_time": position, "length": length, "is_midi": True}
-            for clip in track.arrangement_clips:
-                if abs(clip.start_time - position) < 0.01:
-                    result = self._get_arrangement_clip_info(clip)
-                    break
+
+            create_midi_clip = getattr(track, "create_midi_clip", None)
+            if create_midi_clip is not None:
+                new_clip = create_midi_clip(position, length)
+            else:
+                new_clip = self._create_arrangement_clip_via_session(track, position, length)
+
+            if new_clip is None:
+                for clip in tuple(track.arrangement_clips):
+                    if abs(clip.start_time - position) < 0.01:
+                        new_clip = clip
+                        break
+
+            if new_clip is not None and name:
+                new_clip.name = name
+
+            if new_clip is not None:
+                result = self._get_arrangement_clip_info(new_clip)
+            else:
+                result = {"start_time": position, "length": length, "is_midi": True}
             result["overlapped_clips"] = overlapped
             return result
         except Exception as e:
             self.log_message("Error creating arrangement clip: " + str(e))
             raise
+
+    def _create_arrangement_clip_via_session(self, track, position, length):
+        slot_index = -1
+        for i, slot in enumerate(track.clip_slots):
+            if not slot.has_clip:
+                slot_index = i
+                break
+        if slot_index < 0:
+            raise RuntimeError(
+                "No empty session clip slot available on track '{0}'; "
+                "Live 11 needs one free slot to stage an arrangement MIDI clip".format(
+                    getattr(track, "name", "?")))
+        slot = track.clip_slots[slot_index]
+        slot.create_clip(length)
+        try:
+            return track.duplicate_clip_to_arrangement(slot.clip, position)
+        finally:
+            slot.delete_clip()
 
     def _create_arrangement_audio_clip(self, track_index, position, file_path):
         """Create audio clip in arrangement from file."""

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -1208,7 +1208,7 @@ class AbletonMCP(ControlSurface):
         """Get all cue points."""
         try:
             cue_points = []
-            for cp in self._song.cue_points:
+            for cp in tuple(self._song.cue_points):
                 cue_points.append({"name": cp.name, "time": cp.time})
             return {"cue_points": cue_points}
         except Exception as e:
@@ -1251,7 +1251,7 @@ class AbletonMCP(ControlSurface):
                 self._song.jump_to_prev_cue()
                 return {"direction": "prev", "time": self._song.current_song_time}
             elif name:
-                for cp in self._song.cue_points:
+                for cp in tuple(self._song.cue_points):
                     if cp.name == name:
                         cp.jump()
                         return {"name": cp.name, "time": cp.time}
@@ -1263,18 +1263,37 @@ class AbletonMCP(ControlSurface):
             raise
 
     def _create_cue_point(self, time, name=""):
-        """Create a cue point at the given time."""
+        """Create a cue point at the given time.
+
+        On Live versions where ``CuePoint.name`` is read-only the
+        rename is logged and skipped; the locator keeps Live's
+        auto-generated name.
+        """
         try:
             for cp in tuple(self._song.cue_points):
                 if abs(cp.time - time) < 0.01:
                     raise ValueError("Cue point already exists at this position: " + cp.name)
             self._song.current_song_time = time
-            self._song.set_or_delete_cue()
-            if name:
-                for cp in tuple(self._song.cue_points):
-                    if abs(cp.time - time) < 0.01:
-                        cp.name = name
-                        break
+
+            def _finalize():
+                try:
+                    self._song.set_or_delete_cue()
+                    if name:
+                        for cp in tuple(self._song.cue_points):
+                            if abs(cp.time - time) < 0.01:
+                                try:
+                                    cp.name = name
+                                except (AttributeError, RuntimeError) as e:
+                                    self.log_message(
+                                        "CuePoint.name write rejected by Live: " + str(e))
+                                break
+                except Exception as e:
+                    self.log_message("Error finalizing cue point: " + str(e))
+
+            try:
+                self.schedule_message(1, _finalize)
+            except Exception:
+                _finalize()
             return {"time": time, "name": name}
         except Exception as e:
             self.log_message("Error creating cue point: " + str(e))
@@ -1284,14 +1303,24 @@ class AbletonMCP(ControlSurface):
         """Delete a cue point at the given time."""
         try:
             found = False
-            for cp in self._song.cue_points:
+            for cp in tuple(self._song.cue_points):
                 if abs(cp.time - time) < 0.01:
                     found = True
                     break
             if not found:
                 raise ValueError("No cue point at this position")
             self._song.current_song_time = time
-            self._song.set_or_delete_cue()
+
+            def _finalize():
+                try:
+                    self._song.set_or_delete_cue()
+                except Exception as e:
+                    self.log_message("Error finalizing cue delete: " + str(e))
+
+            try:
+                self.schedule_message(1, _finalize)
+            except Exception:
+                _finalize()
             return {"deleted": True}
         except Exception as e:
             self.log_message("Error deleting cue point: " + str(e))

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -1,4 +1,9 @@
-# ableton_mcp_server.py
+import os
+import sys
+
+if __package__ in (None, ""):
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from mcp.server.fastmcp import FastMCP, Context
 import socket
 import json
@@ -9,6 +14,12 @@ import time
 from dataclasses import dataclass
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Dict, Any, List, Union
+
+from MCP_Server.plugin_aliases import (
+    get_alias_for_param,
+    get_categories,
+    resolve_alias,
+)
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, 
@@ -1411,6 +1422,7 @@ def create_arrangement_midi_clip(
             "track_index": ti,
             "position": position,
             "length": length,
+            "name": name,
         })
 
         msg = (f"Created MIDI clip on track {track_index} at "
@@ -1694,8 +1706,6 @@ def get_device_parameters(
     Specify category or show_all=True for full parameter details.
     """
     try:
-        from MCP_Server.plugin_aliases import get_categories, get_alias_for_param
-
         ableton = get_ableton_connection()
         ti = _to_zero_based(track_index, "track_index")
         di = _to_zero_based(device_index, "device_index")
@@ -1784,8 +1794,6 @@ def set_device_parameter(
     - value: Normalized value 0.0-1.0.
     """
     try:
-        from MCP_Server.plugin_aliases import resolve_alias
-
         ableton = get_ableton_connection()
         ti = _to_zero_based(track_index, "track_index")
         di = _to_zero_based(device_index, "device_index")

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ pip install -e .
 ```
 
 ### 2. **Install Ableton Script**
-1. Find your Ableton Remote Scripts folder:
+1. Find your Ableton User Library Remote Scripts folder:
    - **Windows**: `C:\Users\[You]\Documents\Ableton\User Library\Remote Scripts\`
-   - **Mac**: `~/Library/Preferences/Ableton/Live [Version]/User Remote Scripts/`
+   - **Mac**: `~/Music/Ableton/User Library/Remote Scripts/`
 2. Create folder: `AbletonMCP`
 3. Copy `AbletonMCP_Remote_Script/__init__.py` into this folder
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> Note: This fork adds numerous bug fixes for backward compatability with Live 11.
+
 # Ableton MCP Extended
 **Control Ableton Live using natural language via AI assistants like Claude or Cursor. This project provides a robust Model Context Protocol (MCP) server that translates natural language commands into precise actions within your Ableton Live session.**
 

--- a/tests/unit/test_arrangement_commands.py
+++ b/tests/unit/test_arrangement_commands.py
@@ -232,6 +232,20 @@ class TestCreateArrangementMidiClipCommand:
 
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')
+    def test_passes_name_through(self, mock_conn, mock_ts):
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = {"overlapped_clips": []}
+        mock_conn.return_value = mock_ableton
+
+        from MCP_Server.server import create_arrangement_midi_clip
+        create_arrangement_midi_clip(
+            MagicMock(), track_index=1, start_bar=1, end_bar=5, name="Intro")
+
+        args = mock_ableton.send_command.call_args
+        assert args[0][1]["name"] == "Intro"
+
+    @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
+    @patch('MCP_Server.server.get_ableton_connection')
     def test_overlap_warning(self, mock_conn, mock_ts):
         # When the RS reports overlapped clips, the result should contain a warning
         mock_ableton = MagicMock()

--- a/tests/unit/test_remote_script_helpers.py
+++ b/tests/unit/test_remote_script_helpers.py
@@ -131,6 +131,7 @@ class TestCreateCuePointAssignsName:
     @staticmethod
     def _wire_toggle(script, returned_cue):
         script._song.cue_points = ()
+        script.schedule_message = MagicMock(side_effect=lambda _delay, fn: fn())
 
         def toggle():
             script._song.cue_points = (returned_cue,)
@@ -158,6 +159,86 @@ class TestCreateCuePointAssignsName:
         script._create_cue_point(time=16.0, name="")
 
         assert cue.name == "1.1.1"
+
+
+def _make_cue(time, name):
+    cue = MagicMock()
+    cue.time = time
+    cue.name = name
+    return cue
+
+
+class TestGetCuePoints:
+    def test_returns_all_cues(self):
+        script = _make_script()
+        script._song.cue_points = (
+            _make_cue(0.0, "Intro"),
+            _make_cue(32.0, "Drop"),
+        )
+
+        result = script._get_cue_points()
+
+        assert result == {"cue_points": [
+            {"name": "Intro", "time": 0.0},
+            {"name": "Drop", "time": 32.0},
+        ]}
+
+    def test_empty_when_no_cues(self):
+        script = _make_script()
+        script._song.cue_points = ()
+
+        assert script._get_cue_points() == {"cue_points": []}
+
+
+class TestJumpToCueByName:
+    def test_jumps_to_named_cue(self):
+        script = _make_script()
+        drop = _make_cue(32.0, "Drop")
+        script._song.cue_points = (_make_cue(0.0, "Intro"), drop)
+
+        result = script._jump_to_cue(name="Drop")
+
+        drop.jump.assert_called_once_with()
+        assert result == {"name": "Drop", "time": 32.0}
+
+    def test_raises_when_name_not_found(self):
+        script = _make_script()
+        script._song.cue_points = (_make_cue(0.0, "Intro"),)
+
+        try:
+            script._jump_to_cue(name="Nope")
+        except ValueError as e:
+            assert "Nope" in str(e)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestDeleteCuePoint:
+    def test_deletes_cue_at_time(self):
+        script = _make_script()
+        script._song.cue_points = (
+            _make_cue(0.0, "Intro"),
+            _make_cue(32.0, "Drop"),
+        )
+        script.schedule_message = MagicMock(side_effect=lambda _delay, fn: fn())
+
+        result = script._delete_cue_point(time=32.0)
+
+        assert script._song.current_song_time == 32.0
+        script._song.set_or_delete_cue.assert_called_once_with()
+        assert result == {"deleted": True}
+
+    def test_raises_when_no_cue_at_time(self):
+        script = _make_script()
+        script._song.cue_points = (_make_cue(0.0, "Intro"),)
+
+        try:
+            script._delete_cue_point(time=32.0)
+        except ValueError as e:
+            assert "No cue point" in str(e)
+        else:
+            raise AssertionError("expected ValueError")
+        script._song.set_or_delete_cue.assert_not_called()
 
 
 class _Live12Track(_NormalTrack):

--- a/tests/unit/test_remote_script_helpers.py
+++ b/tests/unit/test_remote_script_helpers.py
@@ -1,0 +1,277 @@
+"""Unit tests for AbletonMCP Remote Script helpers."""
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+class _StubControlSurface:
+    def __init__(self, c_instance):
+        pass
+
+    def log_message(self, msg):
+        pass
+
+
+_framework = types.ModuleType("_Framework")
+_cs_module = types.ModuleType("_Framework.ControlSurface")
+_cs_module.ControlSurface = _StubControlSurface
+sys.modules.setdefault("_Framework", _framework)
+sys.modules.setdefault("_Framework.ControlSurface", _cs_module)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from AbletonMCP_Remote_Script import AbletonMCP  # noqa: E402
+
+
+class _NormalTrack:
+    is_foldable = False
+
+    def __init__(self, name="Track", arm=False, has_midi_input=True,
+                 has_audio_input=False, arrangement_clips=None):
+        self.name = name
+        self.arm = arm
+        self.mute = False
+        self.solo = False
+        self.has_midi_input = has_midi_input
+        self.has_audio_input = has_audio_input
+        self.clip_slots = []
+        self.devices = []
+        self.arrangement_clips = list(arrangement_clips or [])
+        self.mixer_device = MagicMock()
+        self.mixer_device.volume.value = 0.85
+        self.mixer_device.panning.value = 0.0
+
+
+class _GroupTrack:
+    is_foldable = True
+
+    def __init__(self, name="Mix Bus"):
+        self.name = name
+        self.mute = False
+        self.solo = False
+        self.has_midi_input = False
+        self.has_audio_input = False
+        self.clip_slots = []
+        self.devices = []
+        self.mixer_device = MagicMock()
+        self.mixer_device.volume.value = 0.85
+        self.mixer_device.panning.value = 0.0
+
+    @property
+    def arm(self):
+        raise RuntimeError("Master and Return Tracks have no 'Arm' state!")
+
+    @property
+    def arrangement_clips(self):
+        raise RuntimeError(
+            "Master, Group and Return Tracks have no arrangement clips")
+
+
+def _make_script(tracks=()):
+    script = AbletonMCP.__new__(AbletonMCP)
+    script.log_message = lambda _msg: None
+    script._song = MagicMock()
+    script._song.tracks = list(tracks)
+    script._song.return_tracks = []
+    script._song.master_track = MagicMock()
+    return script
+
+
+class TestGetTrackInfoOnGroupTrack:
+    def test_returns_info_without_raising(self):
+        script = _make_script([_GroupTrack("Mix Bus")])
+
+        result = script._get_track_info(0)
+
+        assert result["name"] == "Mix Bus"
+        assert result["is_group_track"] is True
+        assert result["arm"] is None
+
+    def test_normal_track_still_reports_arm(self):
+        script = _make_script([_NormalTrack("Synth", arm=True)])
+
+        result = script._get_track_info(0)
+
+        assert result["arm"] is True
+        assert result["is_group_track"] is False
+
+
+class TestGetArrangementInfoSkipsGroupTracks:
+    def test_all_tracks_skips_group(self):
+        normal = _NormalTrack("Drums")
+        group = _GroupTrack("Mix Bus")
+        script = _make_script([group, normal])
+
+        result = script._get_arrangement_info(-1)
+
+        names = [t["name"] for t in result["tracks"]]
+        assert names == ["Drums"]
+
+    def test_explicit_group_returns_empty_clips(self):
+        script = _make_script([_GroupTrack("Mix Bus")])
+
+        result = script._get_arrangement_info(0)
+
+        assert len(result["tracks"]) == 1
+        assert result["tracks"][0]["arrangement_clips"] == []
+        assert result["tracks"][0]["is_group_track"] is True
+
+    def test_normal_track_unaffected(self):
+        script = _make_script([_NormalTrack("Drums")])
+
+        result = script._get_arrangement_info(0)
+
+        assert result["tracks"][0]["name"] == "Drums"
+        assert result["tracks"][0]["is_group_track"] is False
+
+
+class TestCreateCuePointAssignsName:
+    @staticmethod
+    def _wire_toggle(script, returned_cue):
+        script._song.cue_points = ()
+
+        def toggle():
+            script._song.cue_points = (returned_cue,)
+
+        script._song.set_or_delete_cue.side_effect = toggle
+
+    def test_assigns_name_to_created_cue(self):
+        script = _make_script()
+        cue = MagicMock()
+        cue.time = 16.0
+        cue.name = ""
+        self._wire_toggle(script, cue)
+
+        script._create_cue_point(time=16.0, name="Drop")
+
+        assert cue.name == "Drop"
+
+    def test_blank_name_does_not_overwrite(self):
+        script = _make_script()
+        cue = MagicMock()
+        cue.time = 16.0
+        cue.name = "1.1.1"
+        self._wire_toggle(script, cue)
+
+        script._create_cue_point(time=16.0, name="")
+
+        assert cue.name == "1.1.1"
+
+
+class _Live12Track(_NormalTrack):
+    """Live 12 exposes create_midi_clip(start_time, length) on Track."""
+
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.create_midi_clip = MagicMock()
+
+
+class _Live11Track(_NormalTrack):
+    """Live 11 has no create_midi_clip on Track — must round-trip through a slot."""
+
+    def __init__(self, slots=None, **kw):
+        super().__init__(**kw)
+        self.clip_slots = list(slots or [])
+        self.duplicate_clip_to_arrangement = MagicMock()
+
+
+def _empty_slot():
+    slot = MagicMock()
+    slot.has_clip = False
+    new_clip = MagicMock()
+
+    def _create(length):
+        slot.has_clip = True
+        slot.clip = new_clip
+
+    def _delete():
+        slot.has_clip = False
+        slot.clip = None
+
+    slot.create_clip.side_effect = _create
+    slot.delete_clip.side_effect = _delete
+    return slot, new_clip
+
+
+def _full_slot():
+    slot = MagicMock()
+    slot.has_clip = True
+    return slot
+
+
+class TestCreateArrangementClipLive12:
+    def test_calls_create_midi_clip_with_start_and_length(self):
+        track = _Live12Track()
+        script = _make_script([track])
+
+        script._create_arrangement_clip(track_index=0, position=8.0, length=16.0)
+
+        track.create_midi_clip.assert_called_once_with(8.0, 16.0)
+
+    def test_assigns_name_to_new_clip(self):
+        track = _Live12Track()
+        new_clip = MagicMock()
+        new_clip.start_time = 8.0
+        new_clip.end_time = 12.0
+        track.create_midi_clip.return_value = new_clip
+        script = _make_script([track])
+
+        script._create_arrangement_clip(
+            track_index=0, position=8.0, length=4.0, name="Intro")
+
+        assert new_clip.name == "Intro"
+
+    def test_blank_name_does_not_overwrite(self):
+        track = _Live12Track()
+        new_clip = MagicMock()
+        new_clip.start_time = 0.0
+        new_clip.end_time = 4.0
+        new_clip.name = "Original"
+        track.create_midi_clip.return_value = new_clip
+        script = _make_script([track])
+
+        script._create_arrangement_clip(
+            track_index=0, position=0.0, length=4.0, name="")
+
+        assert new_clip.name == "Original"
+
+
+class TestCreateArrangementClipLive11Fallback:
+    def test_round_trips_through_empty_session_slot(self):
+        empty, new_clip = _empty_slot()
+        track = _Live11Track(slots=[_full_slot(), empty])
+        script = _make_script([track])
+
+        script._create_arrangement_clip(track_index=0, position=8.0, length=4.0)
+
+        empty.create_clip.assert_called_once_with(4.0)
+        track.duplicate_clip_to_arrangement.assert_called_once_with(new_clip, 8.0)
+        empty.delete_clip.assert_called_once_with()
+
+    def test_cleans_up_session_clip_when_duplicate_fails(self):
+        empty, _ = _empty_slot()
+        track = _Live11Track(slots=[empty])
+        track.duplicate_clip_to_arrangement.side_effect = RuntimeError("boom")
+        script = _make_script([track])
+
+        try:
+            script._create_arrangement_clip(track_index=0, position=0.0, length=4.0)
+        except RuntimeError:
+            pass
+
+        empty.delete_clip.assert_called_once_with()
+
+    def test_raises_when_no_empty_slot(self):
+        track = _Live11Track(slots=[_full_slot(), _full_slot()])
+        script = _make_script([track])
+
+        try:
+            script._create_arrangement_clip(track_index=0, position=0.0, length=4.0)
+        except Exception as e:
+            assert "empty" in str(e).lower() or "slot" in str(e).lower()
+        else:
+            raise AssertionError("expected an error when no empty slot is available")
+
+        track.duplicate_clip_to_arrangement.assert_not_called()

--- a/tests/unit/test_script_mode_imports.py
+++ b/tests/unit/test_script_mode_imports.py
@@ -1,0 +1,95 @@
+"""Regression: server.py must work when launched as `python /path/to/server.py`.
+
+Claude Desktop's MCP launcher invokes the server by absolute script path, which
+puts only the script's directory on sys.path — the parent `MCP_Server` package
+is not importable that way, so any `from MCP_Server.X import Y` inside a tool
+handler must be resilient to that layout.
+"""
+import os
+import subprocess
+import sys
+import textwrap
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+PKG_DIR = os.path.join(REPO_ROOT, "MCP_Server")
+SERVER_PATH = os.path.join(PKG_DIR, "server.py")
+
+
+def _run_in_script_mode(snippet: str) -> subprocess.CompletedProcess:
+    bootstrap = textwrap.dedent(
+        f"""
+        import sys
+        from unittest.mock import MagicMock
+        sys.modules['mcp'] = MagicMock()
+        sys.modules['mcp.server'] = MagicMock()
+        fastmcp = MagicMock()
+        fastmcp.FastMCP.return_value.tool.return_value = lambda fn: fn
+        sys.modules['mcp.server.fastmcp'] = fastmcp
+
+        sys.path = [p for p in sys.path if p not in ('', {REPO_ROOT!r})]
+        sys.path.insert(0, {PKG_DIR!r})
+
+        import importlib.util
+        spec = importlib.util.spec_from_file_location('server', {SERVER_PATH!r})
+        server = importlib.util.module_from_spec(spec)
+        sys.modules['server'] = server
+        spec.loader.exec_module(server)
+        """
+    )
+    return subprocess.run(
+        [sys.executable, "-c", bootstrap + "\n" + snippet],
+        capture_output=True,
+        text=True,
+        cwd="/",
+    )
+
+
+def test_get_device_parameters_does_not_crash_on_lazy_import():
+    snippet = textwrap.dedent(
+        """
+        from unittest.mock import MagicMock
+        ableton = MagicMock()
+        ableton.send_command.return_value = {
+            'device_name': 'Pro-Q 3',
+            'device_class': 'PluginDevice',
+            'parameter_count': 1,
+            'parameters': [{
+                'index': 0, 'name': 'Output Gain', 'value': 0.5,
+                'min': 0.0, 'max': 1.0, 'display_value': '0 dB',
+                'is_enabled': True, 'is_quantized': False, 'value_items': [],
+            }],
+        }
+        server.get_ableton_connection = lambda: ableton
+        out = server.get_device_parameters(MagicMock(), track_index=2, device_index=2)
+        print(out)
+        """
+    )
+    proc = _run_in_script_mode(snippet)
+    assert proc.returncode == 0, proc.stderr
+    assert "No module named" not in proc.stdout, proc.stdout
+    assert "Pro-Q 3" in proc.stdout
+
+
+def test_set_device_parameter_does_not_crash_on_lazy_import():
+    snippet = textwrap.dedent(
+        """
+        from unittest.mock import MagicMock
+        ableton = MagicMock()
+        ableton.send_command.side_effect = [
+            {'device_name': 'Pro-Q 3'},
+            {'parameter_name': 'Output Gain', 'display_value': '0 dB',
+             'new_value': 0.5, 'clamped': False},
+        ]
+        server.get_ableton_connection = lambda: ableton
+        out = server.set_device_parameter(
+            MagicMock(), track_index=2, device_index=2,
+            parameter_name='Output Gain', value=0.5,
+        )
+        print(out)
+        """
+    )
+    proc = _run_in_script_mode(snippet)
+    assert proc.returncode == 0, proc.stderr
+    assert "No module named" not in proc.stdout, proc.stdout
+    assert "Output Gain" in proc.stdout


### PR DESCRIPTION
## What's broken

`create_cue_point(bar=N, name=...)` looked like it succeeded but actually toggled the same cue at beat 0 each call. On Live 11, `Song.current_song_time = X` is silently no-op when called inside a `schedule_message` callback, so `Song.set_or_delete_cue()` always ran at the unmoved playhead. Two consecutive creates produced "No cue points in this project" because the second toggled off the first.

## Fix

Defer `set_or_delete_cue()` (and the rename loop) to the next Live tick via `schedule_message(1, ...)`. By then Live has processed the `current_song_time` assignment, so the cue lands at the requested time. Same chain applied to `_delete_cue_point`.

`CuePoint.name = X` is read-only in Live 11 LOM. Assignment failures are caught and logged; cues keep Live's auto-generated locator names ("1", "2", ...) on Live 11. Should work in Live 12 if/when LOM allows the write.

## Tests

`tests/unit/test_remote_script_helpers.py` — added `TestGetCuePoints`, `TestJumpToCueByName`, `TestDeleteCuePoint` covering each lookup path. Existing create tests updated to mock `schedule_message` for the deferred run.

`pytest tests/` → 158 passed.

## Validation against running Live 11.3.43

```
create_cue_point(bar=1, name="Intro")  → cue at bar 1
create_cue_point(bar=9, name="Drop")   → cue at bar 9
get_cue_points()                       → both listed (auto-named "1","2")
delete_cue_point(bar=9)                → bar 9 removed
delete_cue_point(bar=1)                → empty
jump_to_cue_point(name="1")            → jumps to cue
```

## Scope

2 files, +114 / -10.