### PR TITLE
Live 11 compatibility: bug fixes and tool-surface cleanup

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -2025,85 +2025,81 @@ class AbletonMCP(ControlSurface):
             result = {
                 "type": category_type,
                 "categories": [],
-                "available_categories": browser_attrs
+                "available_categories": browser_attrs,
+                "total_folders": 0,
             }
-            
-            # Helper function to process a browser item and its children
-            def process_item(item, depth=0):
+
+            max_depth = 2
+            max_children = 25
+
+            def process_item(item, depth=0, parent_path="", name_override=None):
                 if not item:
-                    return None
-                
-                result = {
-                    "name": item.name if hasattr(item, 'name') else "Unknown",
-                    "is_folder": hasattr(item, 'children') and bool(item.children),
+                    return None, 0
+
+                name = name_override if name_override is not None else (
+                    item.name if hasattr(item, 'name') else "Unknown"
+                )
+                children_iter = tuple(item.children) if hasattr(item, 'children') else ()
+                is_folder = bool(children_iter)
+                item_path = (parent_path + "/" + name) if parent_path else name
+
+                node = {
+                    "name": name,
+                    "is_folder": is_folder,
                     "is_device": hasattr(item, 'is_device') and item.is_device,
                     "is_loadable": hasattr(item, 'is_loadable') and item.is_loadable,
                     "uri": item.uri if hasattr(item, 'uri') else None,
-                    "children": []
+                    "path": item_path,
+                    "children": [],
+                    "has_more": False,
                 }
-                
-                
-                return result
-            
-            # Process based on category type and available attributes
-            if (category_type == "all" or category_type == "instruments") and hasattr(app.browser, 'instruments'):
+                folder_count = 1 if is_folder else 0
+
+                if is_folder and depth < max_depth:
+                    visible = children_iter[:max_children]
+                    if len(children_iter) > max_children:
+                        node["has_more"] = True
+                    for child in visible:
+                        child_node, child_folders = process_item(child, depth + 1, item_path)
+                        if child_node:
+                            node["children"].append(child_node)
+                            folder_count += child_folders
+                elif is_folder and depth >= max_depth:
+                    node["has_more"] = True
+
+                return node, folder_count
+
+            def _append_category(attr, display_name):
                 try:
-                    instruments = process_item(app.browser.instruments)
-                    if instruments:
-                        instruments["name"] = "Instruments"  # Ensure consistent naming
-                        result["categories"].append(instruments)
+                    root_item = getattr(app.browser, attr, None)
+                    if root_item is None:
+                        return
+                    node, folder_count = process_item(root_item, name_override=display_name)
+                    if node is None:
+                        return
+                    result["categories"].append(node)
+                    result["total_folders"] += folder_count
                 except Exception as e:
-                    self.log_message("Error processing instruments: {0}".format(str(e)))
-            
-            if (category_type == "all" or category_type == "sounds") and hasattr(app.browser, 'sounds'):
-                try:
-                    sounds = process_item(app.browser.sounds)
-                    if sounds:
-                        sounds["name"] = "Sounds"  # Ensure consistent naming
-                        result["categories"].append(sounds)
-                except Exception as e:
-                    self.log_message("Error processing sounds: {0}".format(str(e)))
-            
-            if (category_type == "all" or category_type == "drums") and hasattr(app.browser, 'drums'):
-                try:
-                    drums = process_item(app.browser.drums)
-                    if drums:
-                        drums["name"] = "Drums"  # Ensure consistent naming
-                        result["categories"].append(drums)
-                except Exception as e:
-                    self.log_message("Error processing drums: {0}".format(str(e)))
-            
-            if (category_type == "all" or category_type == "audio_effects") and hasattr(app.browser, 'audio_effects'):
-                try:
-                    audio_effects = process_item(app.browser.audio_effects)
-                    if audio_effects:
-                        audio_effects["name"] = "Audio Effects"  # Ensure consistent naming
-                        result["categories"].append(audio_effects)
-                except Exception as e:
-                    self.log_message("Error processing audio_effects: {0}".format(str(e)))
-            
-            if (category_type == "all" or category_type == "midi_effects") and hasattr(app.browser, 'midi_effects'):
-                try:
-                    midi_effects = process_item(app.browser.midi_effects)
-                    if midi_effects:
-                        midi_effects["name"] = "MIDI Effects"
-                        result["categories"].append(midi_effects)
-                except Exception as e:
-                    self.log_message("Error processing midi_effects: {0}".format(str(e)))
-            
-            # Try to process other potentially available categories
+                    self.log_message("Error processing {0}: {1}".format(attr, str(e)))
+
+            named_categories = [
+                ("instruments", "Instruments"),
+                ("sounds", "Sounds"),
+                ("drums", "Drums"),
+                ("audio_effects", "Audio Effects"),
+                ("midi_effects", "MIDI Effects"),
+            ]
+            for attr, display_name in named_categories:
+                if (category_type == "all" or category_type == attr) and hasattr(app.browser, attr):
+                    _append_category(attr, display_name)
+
+            handled = {attr for attr, _ in named_categories}
             for attr in browser_attrs:
-                if attr not in ['instruments', 'sounds', 'drums', 'audio_effects', 'midi_effects'] and \
-                   (category_type == "all" or category_type == attr):
-                    try:
-                        item = getattr(app.browser, attr)
-                        if hasattr(item, 'children') or hasattr(item, 'name'):
-                            category = process_item(item)
-                            if category:
-                                category["name"] = attr.capitalize()
-                                result["categories"].append(category)
-                    except Exception as e:
-                        self.log_message("Error processing {0}: {1}".format(attr, str(e)))
+                if attr in handled:
+                    continue
+                if category_type != "all" and category_type != attr:
+                    continue
+                _append_category(attr, attr.capitalize())
             
             self.log_message("Browser tree generated for {0} with {1} root categories".format(
                 category_type, len(result['categories'])))

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -1207,7 +1207,7 @@ class AbletonMCP(ControlSurface):
         """Get all cue points."""
         try:
             cue_points = []
-            for cp in self._song.cue_points:
+            for cp in tuple(self._song.cue_points):
                 cue_points.append({"name": cp.name, "time": cp.time})
             return {"cue_points": cue_points}
         except Exception as e:
@@ -1250,7 +1250,7 @@ class AbletonMCP(ControlSurface):
                 self._song.jump_to_prev_cue()
                 return {"direction": "prev", "time": self._song.current_song_time}
             elif name:
-                for cp in self._song.cue_points:
+                for cp in tuple(self._song.cue_points):
                     if cp.name == name:
                         cp.jump()
                         return {"name": cp.name, "time": cp.time}
@@ -1262,18 +1262,33 @@ class AbletonMCP(ControlSurface):
             raise
 
     def _create_cue_point(self, time, name=""):
-        """Create a cue point at the given time."""
+        """Create a cue point at the given time.
+
+        If ``name`` is provided, the locator is renamed after creation;
+        rename failures are logged.
+        """
         try:
             for cp in tuple(self._song.cue_points):
                 if abs(cp.time - time) < 0.01:
                     raise ValueError("Cue point already exists at this position: " + cp.name)
             self._song.current_song_time = time
-            self._song.set_or_delete_cue()
-            if name:
-                for cp in tuple(self._song.cue_points):
-                    if abs(cp.time - time) < 0.01:
-                        cp.name = name
-                        break
+
+            def _finalize():
+                try:
+                    self._song.set_or_delete_cue()
+                    if name:
+                        for cp in tuple(self._song.cue_points):
+                            if abs(cp.time - time) < 0.01:
+                                try:
+                                    cp.name = name
+                                except (AttributeError, RuntimeError) as e:
+                                    self.log_message(
+                                        "CuePoint.name assignment failed: " + str(e))
+                                break
+                except Exception as e:
+                    self.log_message("Error finalizing cue point: " + str(e))
+
+            self.schedule_message(1, _finalize)
             return {"time": time, "name": name}
         except Exception as e:
             self.log_message("Error creating cue point: " + str(e))
@@ -1283,14 +1298,21 @@ class AbletonMCP(ControlSurface):
         """Delete a cue point at the given time."""
         try:
             found = False
-            for cp in self._song.cue_points:
+            for cp in tuple(self._song.cue_points):
                 if abs(cp.time - time) < 0.01:
                     found = True
                     break
             if not found:
                 raise ValueError("No cue point at this position")
             self._song.current_song_time = time
-            self._song.set_or_delete_cue()
+
+            def _finalize():
+                try:
+                    self._song.set_or_delete_cue()
+                except Exception as e:
+                    self.log_message("Error finalizing cue delete: " + str(e))
+
+            self.schedule_message(1, _finalize)
             return {"deleted": True}
         except Exception as e:
             self.log_message("Error deleting cue point: " + str(e))

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -1335,7 +1335,7 @@ class AbletonMCP(ControlSurface):
             raise
 
     def _validate_not_return_or_master(self, track_index):
-        """Raise if track is a return or master track."""
+        """Raise if track is a return, master, or group (foldable) track."""
         track = self._song.tracks[track_index]
         # Return tracks and master track are separate in the Live API,
         # but if accessed via tracks list they are regular tracks.
@@ -1345,6 +1345,10 @@ class AbletonMCP(ControlSurface):
                 raise ValueError("Cannot create arrangement clips on return track '{0}'".format(track.name))
         if track == self._song.master_track:
             raise ValueError("Cannot create arrangement clips on master track")
+        # Group tracks are foldable. They have no usable clip_slots/arrangement_clips
+        # for our purposes — the Live 11 fallback would iterate to no avail.
+        if getattr(track, "is_foldable", False):
+            raise ValueError("Cannot create arrangement clips on group track '{0}'".format(track.name))
 
     def _create_arrangement_clip(self, track_index, position, length, name=""):
         """Create MIDI clip in arrangement.

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -318,7 +318,8 @@ class AbletonMCP(ControlSurface):
                             ti = params.get("track_index", 0)
                             pos = params.get("position", 0.0)
                             length = params.get("length", 4.0)
-                            result = self._create_arrangement_clip(ti, pos, length)
+                            name = params.get("name", "")
+                            result = self._create_arrangement_clip(ti, pos, length, name=name)
                         elif command_type == "create_arrangement_audio_clip":
                             ti = params.get("track_index", 0)
                             pos = params.get("position", 0.0)
@@ -1345,26 +1346,62 @@ class AbletonMCP(ControlSurface):
         if track == self._song.master_track:
             raise ValueError("Cannot create arrangement clips on master track")
 
-    def _create_arrangement_clip(self, track_index, position, length):
-        """Create MIDI clip in arrangement."""
+    def _create_arrangement_clip(self, track_index, position, length, name=""):
+        """Create MIDI clip in arrangement.
+
+        Live 12 exposes Track.create_midi_clip(start_time, length) directly.
+        Live 11 has no such method, so round-trip through a session slot:
+        create_clip -> duplicate_clip_to_arrangement -> delete the session clip.
+        """
         try:
             if track_index < 0 or track_index >= len(self._song.tracks):
                 raise IndexError("Track index out of range")
             self._validate_not_return_or_master(track_index)
             track = self._song.tracks[track_index]
             overlapped = self._check_overlap(track, position, length)
-            track.create_midi_clip(position, length)
-            # Find the newly created clip
-            result = {"start_time": position, "length": length, "is_midi": True}
-            for clip in track.arrangement_clips:
-                if abs(clip.start_time - position) < 0.01:
-                    result = self._get_arrangement_clip_info(clip)
-                    break
+
+            create_midi_clip = getattr(track, "create_midi_clip", None)
+            if create_midi_clip is not None:
+                new_clip = create_midi_clip(position, length)
+            else:
+                new_clip = self._create_arrangement_clip_via_session(track, position, length)
+
+            if new_clip is None:
+                for clip in tuple(track.arrangement_clips):
+                    if abs(clip.start_time - position) < 0.01:
+                        new_clip = clip
+                        break
+
+            if new_clip is not None and name:
+                new_clip.name = name
+
+            if new_clip is not None:
+                result = self._get_arrangement_clip_info(new_clip)
+            else:
+                result = {"start_time": position, "length": length, "is_midi": True}
             result["overlapped_clips"] = overlapped
             return result
         except Exception as e:
             self.log_message("Error creating arrangement clip: " + str(e))
             raise
+
+    def _create_arrangement_clip_via_session(self, track, position, length):
+        slot_index = -1
+        for i, slot in enumerate(track.clip_slots):
+            if not slot.has_clip:
+                slot_index = i
+                break
+        if slot_index < 0:
+            raise RuntimeError(
+                "No empty session clip slot available on track '{0}'; "
+                "Live 11 needs one free slot to stage an arrangement MIDI clip".format(
+                    getattr(track, "name", "?")))
+        slot = track.clip_slots[slot_index]
+        slot.create_clip(length)
+        try:
+            return track.duplicate_clip_to_arrangement(slot.clip, position)
+        finally:
+            slot.delete_clip()
 
     def _create_arrangement_audio_clip(self, track_index, position, file_path):
         """Create audio clip in arrangement from file."""

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -349,10 +349,11 @@ class AbletonMCP(ControlSurface):
                             result = self._control_arrangement_view(action, ti)
                         elif command_type == "manage_clip_automation":
                             ti = params.get("track_index", 0)
-                            ci = params.get("clip_index", 0)
+                            ci = params.get("clip_index", None)
+                            cn = params.get("clip_name", None)
                             action = params.get("action", "create")
                             pn = params.get("parameter_name", "")
-                            result = self._manage_clip_automation(ti, ci, action, pn)
+                            result = self._manage_clip_automation(ti, ci, action, pn, cn)
                         elif command_type == "add_notes_to_arrangement_clip":
                             ti = params.get("track_index", 0)
                             ci = params.get("clip_index", 0)
@@ -1495,39 +1496,16 @@ class AbletonMCP(ControlSurface):
             self.log_message("Error controlling arrangement view: " + str(e))
             raise
 
-    def _manage_clip_automation(self, track_index, clip_index, action, parameter_name=""):
-        """Create or clear automation envelopes."""
+    def _manage_clip_automation(self, track_index, clip_index, action,
+                                parameter_name="", clip_name=None):
+        """Create or clear automation envelopes on a session clip."""
         try:
-            track, clip = self._resolve_arrangement_clip(track_index, clip_index)
+            track, clip = self._resolve_session_clip(
+                track_index, clip_index, clip_name)
             if action == "clear_all":
                 clip.clear_all_envelopes()
                 return {"action": "clear_all", "done": True}
-            # Find the parameter
-            param = None
-            # Check mixer device first
-            mixer = track.mixer_device
-            for p in [mixer.volume, mixer.panning]:
-                if p.name.lower() == parameter_name.lower():
-                    param = p
-                    break
-            # Check sends
-            if param is None:
-                for send in mixer.sends:
-                    if send.name.lower() == parameter_name.lower():
-                        param = send
-                        break
-            # Check track devices
-            if param is None:
-                for device in track.devices:
-                    for p in device.parameters:
-                        if p.name.lower() == parameter_name.lower():
-                            param = p
-                            break
-                    if param:
-                        break
-            if param is None:
-                raise ValueError("Parameter '{0}' not found on track '{1}'".format(
-                    parameter_name, track.name))
+            param = self._find_automatable_parameter(track, parameter_name)
             if action == "create":
                 clip.create_automation_envelope(param)
                 return {"action": "create", "parameter": param.name, "done": True}
@@ -1539,6 +1517,63 @@ class AbletonMCP(ControlSurface):
         except Exception as e:
             self.log_message("Error managing clip automation: " + str(e))
             raise
+
+    def _resolve_session_clip(self, track_index, clip_index=None, clip_name=None):
+        """Resolve a session clip by slot index or clip name."""
+        if track_index < 0 or track_index >= len(self._song.tracks):
+            raise IndexError("Track index {0} out of range (0-{1})".format(
+                track_index, len(self._song.tracks) - 1))
+        track = self._song.tracks[track_index]
+        slots = tuple(track.clip_slots)
+
+        if clip_name:
+            matches = [(i, s.clip) for i, s in enumerate(slots)
+                       if s.has_clip and s.clip.name == clip_name]
+            if not matches:
+                raise ValueError("No session clip named '{0}' on track '{1}'".format(
+                    clip_name, track.name))
+            if len(matches) > 1:
+                raise ValueError("Ambiguous: {0} session clips named '{1}' on track '{2}'".format(
+                    len(matches), clip_name, track.name))
+            return track, matches[0][1]
+
+        if clip_index is None:
+            raise ValueError("Either clip_index or clip_name must be provided")
+        if clip_index < 0 or clip_index >= len(slots):
+            raise IndexError("Clip slot {0} out of range (0-{1}) on track '{2}'".format(
+                clip_index, len(slots) - 1, track.name))
+        slot = slots[clip_index]
+        if not slot.has_clip:
+            raise ValueError("No clip in session slot {0} on track '{1}'".format(
+                clip_index, track.name))
+        return track, slot.clip
+
+    def _find_automatable_parameter(self, track, parameter_name):
+        """Find a parameter on a track by name, with mixer-volume/pan aliases."""
+        if not parameter_name:
+            raise ValueError("parameter_name is required")
+        target = parameter_name.strip().lower()
+        mixer = track.mixer_device
+
+        aliases = {
+            "volume": mixer.volume,
+            "track volume": mixer.volume,
+            "pan": mixer.panning,
+            "panning": mixer.panning,
+            "track panning": mixer.panning,
+        }
+        if target in aliases:
+            return aliases[target]
+
+        for send in tuple(mixer.sends):
+            if send.name.strip().lower() == target:
+                return send
+        for device in tuple(track.devices):
+            for p in tuple(device.parameters):
+                if p.name.strip().lower() == target:
+                    return p
+        raise ValueError("Parameter '{0}' not found on track '{1}'".format(
+            parameter_name, track.name))
 
     # ── Device command handlers ──────────────────────────────────────
 

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -7,6 +7,7 @@ import json
 import threading
 import time
 import traceback
+from collections import Counter
 
 # Change queue import for Python 2
 try:
@@ -1103,15 +1104,28 @@ class AbletonMCP(ControlSurface):
             
             # Select the track
             self._song.view.selected_track = track
-            
+
+            devices_before = [d.name for d in tuple(track.devices)]
+
             # Load the item
             app.browser.load_item(item)
-            
+
+            devices_after = [d.name for d in tuple(track.devices)]
+            remaining = Counter(devices_before)
+            new_devices = []
+            for name in devices_after:
+                if remaining[name] > 0:
+                    remaining[name] -= 1
+                else:
+                    new_devices.append(name)
+
             result = {
                 "loaded": True,
                 "item_name": item.name,
                 "track_name": track.name,
-                "uri": item_uri
+                "uri": item_uri,
+                "devices_after": devices_after,
+                "new_devices": new_devices,
             }
             return result
         except Exception as e:

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -1362,7 +1362,10 @@ class AbletonMCP(ControlSurface):
 
             create_midi_clip = getattr(track, "create_midi_clip", None)
             if create_midi_clip is not None:
-                new_clip = create_midi_clip(position, length)
+                # Live 12: LOM does not document a return value for
+                # Track.create_midi_clip, so don't trust it — scan instead.
+                create_midi_clip(position, length)
+                new_clip = None
             else:
                 new_clip = self._create_arrangement_clip_via_session(track, position, length)
 

--- a/LIVE_11_NOTES.md
+++ b/LIVE_11_NOTES.md
@@ -1,0 +1,21 @@
+# Live 11 Compatibility Notes
+
+This project supports Ableton Live 11 and Live 12. The tools work on both, but Live 11's Live API is more limited in two end-user-visible ways.
+
+## Cue point names are read-only on Live 11
+
+`CuePoint.name` is read-only in Live 11's Live API; the assignment is silently dropped. When you create a cue point:
+
+- **Live 12:** the `name` you pass is applied (`"Verse"`, `"Drop"`, …).
+- **Live 11:** Live assigns its own auto-generated locator name (`"1"`, `"2"`, `"3"`, …) regardless of what you pass.
+
+`create_cue_point`'s response reflects what Live actually saved, not what you requested. Tools that look up cues by name (`jump_to_cue_point(name=…)`, name-based `delete_cue_point`) will only find them by Live's auto-generated names on Live 11. If your workflow depends on named cues, on Live 11 use direction-based jumps (`prev`/`next`) or jump by the locator name Live assigned.
+
+## Creating an arrangement MIDI clip needs an empty session slot on Live 11
+
+`Track.create_midi_clip(start_time, length)` is a Live 12 API; Live 11's `Track` has no such method. The Live 11 path stages a session-view clip and duplicates it into the arrangement, deleting the staged clip afterwards.
+
+- **Live 12:** `create_arrangement_midi_clip` works on any track.
+- **Live 11:** the target track must have at least one empty session-clip slot. If all slots are full, the call fails with `"No empty session clip slot available on track 'X'; Live 11 needs one free slot to stage an arrangement MIDI clip"`.
+
+Free up a session slot on the target track before calling `create_arrangement_midi_clip`.

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -1365,7 +1365,20 @@ def jump_to_cue_point(ctx: Context, direction: str = "", name: str = "") -> str:
         if name:
             params["name"] = name
         result = ableton.send_command("jump_to_cue", params)
-        return f"Jumped to cue point: {result}"
+
+        landed_name = result.get("name")
+        landed_dir = result.get("direction")
+        time_val = result.get("time")
+        location = ""
+        if time_val is not None:
+            num, denom = _get_time_signature()
+            location = f" at bar {beat_to_bar(time_val, num, denom)}"
+
+        if landed_name:
+            return f"Jumped to cue point '{landed_name}'{location}"
+        if landed_dir:
+            return f"Jumped {landed_dir} to cue point{location}"
+        return f"Jumped to cue point{location}"
     except Exception as e:
         logger.error(f"Error jumping to cue point: {str(e)}")
         return f"Error jumping to cue point: {str(e)}"
@@ -1422,7 +1435,11 @@ def create_cue_point(ctx: Context, bar: int = 0, beat: float = 0.0, name: str = 
         ableton = get_ableton_connection()
         time_val = _convert_bar_to_beat(bar, beat)
         ableton.send_command("create_cue_point", {"time": time_val, "name": name})
-        bar_str = str(bar) if bar > 0 else "?"
+        if bar > 0:
+            bar_str = str(bar)
+        else:
+            num, denom = _get_time_signature()
+            bar_str = str(beat_to_bar(time_val, num, denom))
         actual_name = _readback_cue_name(ableton, time_val)
         if actual_name is None:
             return f"Created cue point at bar {bar_str}"
@@ -1449,7 +1466,11 @@ def delete_cue_point(ctx: Context, bar: int = 0, beat: float = 0.0) -> str:
         ableton = get_ableton_connection()
         time_val = _convert_bar_to_beat(bar, beat)
         ableton.send_command("delete_cue_point", {"time": time_val})
-        bar_str = str(bar) if bar > 0 else "?"
+        if bar > 0:
+            bar_str = str(bar)
+        else:
+            num, denom = _get_time_signature()
+            bar_str = str(beat_to_bar(time_val, num, denom))
         if _readback_cue_absent(ableton, time_val):
             return f"Deleted cue point at bar {bar_str}"
         return (f"Delete request sent for bar {bar_str}, but cue still "
@@ -1850,10 +1871,16 @@ def get_device_parameters(
             groups.setdefault(cat, []).append(p)
 
         lines = ["{0} — {1} parameters total".format(device_name, param_count), ""]
-        for cat_name, cat_params in groups.items():
-            lines.append("  {0}: {1} parameters".format(cat_name, len(cat_params)))
-        lines.append("")
-        lines.append("Use category='<name>' or show_all=True for full details.")
+        if len(groups) == 1:
+            # Only one bucket — categorization isn't informative for this device
+            # (typically: device has no defined category prefixes, or all params
+            # share one prefix). Skip the bucket display, point at show_all.
+            lines.append("Use show_all=True for full parameter details.")
+        else:
+            for cat_name, cat_params in groups.items():
+                lines.append("  {0}: {1} parameters".format(cat_name, len(cat_params)))
+            lines.append("")
+            lines.append("Use category='<name>' or show_all=True for full details.")
         return "\n".join(lines)
     except Exception as e:
         logger.error(f"Error getting device parameters: {str(e)}")
@@ -1864,21 +1891,22 @@ def get_device_parameters(
 def set_device_parameter(
     ctx: Context,
     track_index: int,
+    value: float,
     device_index: int = 1,
     chain_index: int = 0,
     parameter_name: str = "",
     parameter_index: int = 0,
-    value: float = 0.0,
 ) -> str:
     """Set a device parameter value.
 
     Parameters:
     - track_index: Track number (1-based).
+    - value: Normalized value 0.0-1.0 (required — pass as ``value=``, not
+      a synonym like ``normalized_value=``).
     - device_index: Device number (1-based, default 1).
     - chain_index: Chain number inside a rack (1-based, 0 = no chain).
     - parameter_name: Parameter name, friendly alias, or partial match.
     - parameter_index: Parameter number (1-based, alternative to name).
-    - value: Normalized value 0.0-1.0.
     """
     try:
         ableton = get_ableton_connection()
@@ -2231,6 +2259,11 @@ def navigate_device_preset(
     direction: str = "next",
 ) -> str:
     """Navigate device presets (next/previous/current).
+
+    Note: only plugin (VST/AU) devices expose presets via this API. Stock
+    Live devices (Operator, Drum Rack, etc.) will return
+    ``Device 'X' has no presets available``; load their factory patches via
+    the browser instead (``load_instrument_or_effect`` / ``load_drum_kit``).
 
     Parameters:
     - track_index: Track number (1-based).

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -1371,6 +1371,24 @@ def jump_to_cue_point(ctx: Context, direction: str = "", name: str = "") -> str:
         return f"Error jumping to cue point: {str(e)}"
 
 
+def _readback_cue_name(ableton, time_val: float, attempts: int = 4, delay: float = 0.05):
+    """Return the actual locator name at ``time_val`` after a create.
+
+    The Remote Script defers cue creation + rename via ``schedule_message`` so
+    the remote can move the playhead first; a tight retry covers the race
+    between our follow-up read and Live's tick.
+    """
+    import time as _time
+    for i in range(attempts):
+        result = ableton.send_command("get_cue_points", {})
+        for cp in result.get("cue_points", []):
+            if abs(cp.get("time", -1) - time_val) < 0.01:
+                return cp.get("name", "")
+        if i < attempts - 1:
+            _time.sleep(delay)
+    return None
+
+
 @mcp.tool()
 def create_cue_point(ctx: Context, bar: int = 0, beat: float = 0.0, name: str = "") -> str:
     """Create a cue point at a position.
@@ -1383,8 +1401,17 @@ def create_cue_point(ctx: Context, bar: int = 0, beat: float = 0.0, name: str = 
     try:
         ableton = get_ableton_connection()
         time_val = _convert_bar_to_beat(bar, beat)
-        result = ableton.send_command("create_cue_point", {"time": time_val, "name": name})
-        return f"Created cue point '{name}' at bar {bar if bar > 0 else '?'}"
+        ableton.send_command("create_cue_point", {"time": time_val, "name": name})
+        bar_str = str(bar) if bar > 0 else "?"
+        actual_name = _readback_cue_name(ableton, time_val)
+        if actual_name is None:
+            return f"Created cue point at bar {bar_str}"
+        if name and actual_name != name:
+            return (f"Created cue point '{actual_name}' at bar {bar_str} "
+                    f"(requested name '{name}' not applied)")
+        if actual_name:
+            return f"Created cue point '{actual_name}' at bar {bar_str}"
+        return f"Created cue point at bar {bar_str}"
     except Exception as e:
         logger.error(f"Error creating cue point: {str(e)}")
         return f"Error creating cue point: {str(e)}"

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -1389,6 +1389,26 @@ def _readback_cue_name(ableton, time_val: float, attempts: int = 4, delay: float
     return None
 
 
+def _readback_cue_absent(ableton, time_val: float, attempts: int = 4, delay: float = 0.05):
+    """Return True once the cue at ``time_val`` is gone after a delete.
+
+    Symmetric to ``_readback_cue_name`` — the Remote Script defers
+    ``set_or_delete_cue`` via ``schedule_message`` so the playhead set lands
+    first, and the readback covers the tick race.
+    """
+    import time as _time
+    for i in range(attempts):
+        result = ableton.send_command("get_cue_points", {})
+        present = any(
+            abs(cp.get("time", -1) - time_val) < 0.01
+            for cp in result.get("cue_points", []))
+        if not present:
+            return True
+        if i < attempts - 1:
+            _time.sleep(delay)
+    return False
+
+
 @mcp.tool()
 def create_cue_point(ctx: Context, bar: int = 0, beat: float = 0.0, name: str = "") -> str:
     """Create a cue point at a position.
@@ -1429,7 +1449,11 @@ def delete_cue_point(ctx: Context, bar: int = 0, beat: float = 0.0) -> str:
         ableton = get_ableton_connection()
         time_val = _convert_bar_to_beat(bar, beat)
         ableton.send_command("delete_cue_point", {"time": time_val})
-        return f"Deleted cue point at bar {bar if bar > 0 else '?'}"
+        bar_str = str(bar) if bar > 0 else "?"
+        if _readback_cue_absent(ableton, time_val):
+            return f"Deleted cue point at bar {bar_str}"
+        return (f"Delete request sent for bar {bar_str}, but cue still "
+                f"present after readback (Live tick race)")
     except Exception as e:
         logger.error(f"Error deleting cue point: {str(e)}")
         return f"Error deleting cue point: {str(e)}"

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -1474,6 +1474,7 @@ def create_arrangement_midi_clip(
             "track_index": ti,
             "position": position,
             "length": length,
+            "name": name,
         })
 
         msg = (f"Created MIDI clip on track {track_index} at "

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -1128,6 +1128,13 @@ def load_external_plugin(
         return f"Error loading external plugin: {str(e)}"
 
 
+_BROWSER_URI_SCHEME_RE = re.compile(r"^[a-z][a-z0-9.+-]*:")
+
+
+def _looks_like_browser_uri(value: str) -> bool:
+    return isinstance(value, str) and bool(_BROWSER_URI_SCHEME_RE.match(value))
+
+
 @mcp.tool()
 def load_drum_kit(ctx: Context, track_index: int, rack_uri: str, kit_path: str) -> str:
     """
@@ -1135,45 +1142,51 @@ def load_drum_kit(ctx: Context, track_index: int, rack_uri: str, kit_path: str) 
 
     Parameters:
     - track_index: Track number (1-based).
-    - rack_uri: The URI of the drum rack to load (e.g., 'Drums/Drum Rack').
-    - kit_path: Path to the drum kit inside the browser (e.g., 'drums/acoustic/kit1').
+    - rack_uri: Browser URI of the drum rack (e.g., 'query:Drums#Drum%20Rack').
+    - kit_path: Either a browser URI of the kit (e.g., 'query:Drums#FileId_4197')
+                or a browser path. Stock kits live as .adg leaves directly under
+                'drums', e.g. 'drums/808 Core Kit.adg'. Folder paths fall back
+                to loading the first loadable child (e.g. 'user-library/My Kits').
     """
     try:
         ableton = get_ableton_connection()
         ti = _to_zero_based(track_index, "track_index")
 
-        # Step 1: Load the drum rack
-        result = ableton.send_command("load_browser_item", {
+        rack_result = ableton.send_command("load_browser_item", {
             "track_index": ti,
-            "item_uri": rack_uri
+            "item_uri": rack_uri,
         })
-        
-        if not result.get("loaded", False):
+        if not rack_result.get("loaded", False):
             return f"Failed to load drum rack with URI '{rack_uri}'"
-        
-        # Step 2: Get the drum kit items at the specified path
-        kit_result = ableton.send_command("get_browser_items_at_path", {
-            "path": kit_path
-        })
-        
-        if "error" in kit_result:
-            return f"Loaded drum rack but failed to find drum kit: {kit_result.get('error')}"
-        
-        # Step 3: Find a loadable drum kit
-        kit_items = kit_result.get("items", [])
-        loadable_kits = [item for item in kit_items if item.get("is_loadable", False)]
-        
-        if not loadable_kits:
-            return f"Loaded drum rack but no loadable drum kits found at '{kit_path}'"
-        
-        # Step 4: Load the first loadable kit
-        kit_uri = loadable_kits[0].get("uri")
-        load_result = ableton.send_command("load_browser_item", {
+
+        if _looks_like_browser_uri(kit_path):
+            kit_uri = kit_path
+            kit_name = kit_path
+        else:
+            kit_result = ableton.send_command("get_browser_items_at_path", {
+                "path": kit_path,
+            })
+            if "error" in kit_result:
+                return f"Loaded drum rack but failed to find drum kit: {kit_result.get('error')}"
+
+            if kit_result.get("is_loadable") and kit_result.get("uri"):
+                kit_uri = kit_result["uri"]
+                kit_name = kit_result.get("name") or kit_path
+            else:
+                loadable_kits = [
+                    item for item in kit_result.get("items", [])
+                    if item.get("is_loadable", False)
+                ]
+                if not loadable_kits:
+                    return f"Loaded drum rack but no loadable drum kits found at '{kit_path}'"
+                kit_uri = loadable_kits[0].get("uri")
+                kit_name = loadable_kits[0].get("name")
+
+        ableton.send_command("load_browser_item", {
             "track_index": ti,
-            "item_uri": kit_uri
+            "item_uri": kit_uri,
         })
-        
-        return f"Loaded drum rack and kit '{loadable_kits[0].get('name')}' on track {track_index}"
+        return f"Loaded drum rack and kit '{kit_name}' on track {track_index}"
     except Exception as e:
         logger.error(f"Error loading drum kit: {str(e)}")
         return f"Error loading drum kit: {str(e)}"

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -1665,29 +1665,40 @@ def manage_clip_automation(
     action: str = "create",
     parameter_name: str = "volume",
 ) -> str:
-    """Create or clear automation envelopes on arrangement clips.
+    """Create or clear automation envelopes on a session clip.
+
+    Live's Clip.create_automation_envelope only accepts session clips, so
+    this tool resolves against the track's clip_slots.
 
     Parameters:
     - track_index: Track number (1-based).
-    - clip_index: Clip position (1-based).
-    - clip_name: Clip name (alternative to clip_index).
+    - clip_index: Session clip slot (1-based). Ignored when clip_name is set.
+    - clip_name: Resolve by clip name across the track's slots.
     - action: "create", "clear", or "clear_all".
-    - parameter_name: Parameter to automate (e.g., "volume", "panning").
+    - parameter_name: Parameter to automate. Aliases "volume" and "panning"
+      map to Track Volume / Track Panning. Otherwise matched by exact
+      (case-insensitive) name against mixer sends and devices on the track.
     """
     try:
         ableton = get_ableton_connection()
         ti = _to_zero_based(track_index, "track_index")
-        ci = _to_zero_based(clip_index, "clip_index") if clip_index > 0 else 0
-        result = ableton.send_command("manage_clip_automation", {
+        payload = {
             "track_index": ti,
-            "clip_index": ci,
             "action": action,
             "parameter_name": parameter_name,
-        })
+        }
+        if clip_name:
+            payload["clip_name"] = clip_name
+        else:
+            payload["clip_index"] = _to_zero_based(clip_index, "clip_index")
 
+        result = ableton.send_command("manage_clip_automation", payload)
+
+        target = clip_name or f"slot {clip_index}"
         if action == "clear_all":
-            return f"Cleared all automation on clip {clip_index}, track {track_index}"
-        return f"Automation {action}: {parameter_name} on clip {clip_index}, track {track_index}"
+            return f"Cleared all automation on {target}, track {track_index}"
+        param = result.get("parameter", parameter_name)
+        return f"Automation {action}: {param} on {target}, track {track_index}"
     except Exception as e:
         logger.error(f"Error managing clip automation: {str(e)}")
         return f"Error managing clip automation: {str(e)}"

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -415,6 +415,15 @@ def get_track_info(ctx: Context, track_index: int) -> str:
         ableton = get_ableton_connection()
         ti = _to_zero_based(track_index, "track_index")
         result = ableton.send_command("get_track_info", {"track_index": ti})
+        if isinstance(result, dict):
+            if isinstance(result.get("index"), int):
+                result["index"] = result["index"] + 1
+            for key in ("clip_slots", "devices"):
+                items = result.get(key)
+                if isinstance(items, list):
+                    for item in items:
+                        if isinstance(item, dict) and isinstance(item.get("index"), int):
+                            item["index"] = item["index"] + 1
         return json.dumps(result, indent=2)
     except Exception as e:
         logger.error(f"Error getting track info from Ableton: {str(e)}")
@@ -664,14 +673,17 @@ def load_instrument_or_effect(ctx: Context, track_index: int, uri: str) -> str:
             "item_uri": uri
         })
         
-        # Check if the instrument was loaded successfully
         if result.get("loaded", False):
             new_devices = result.get("new_devices", [])
             if new_devices:
                 return f"Loaded instrument with URI '{uri}' on track {track_index}. New devices: {', '.join(new_devices)}"
-            else:
-                devices = result.get("devices_after", [])
+            devices = result.get("devices_after", [])
+            if devices:
                 return f"Loaded instrument with URI '{uri}' on track {track_index}. Devices on track: {', '.join(devices)}"
+            item_name = result.get("item_name", "")
+            if item_name:
+                return f"Loaded '{item_name}' on track {track_index}."
+            return f"Loaded instrument with URI '{uri}' on track {track_index}."
         else:
             return f"Failed to load instrument with URI '{uri}'"
     except Exception as e:

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -1,4 +1,9 @@
-# ableton_mcp_server.py
+import os
+import sys
+
+if __package__ in (None, ""):
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from mcp.server.fastmcp import FastMCP, Context
 import socket
 import json
@@ -9,6 +14,12 @@ import time
 from dataclasses import dataclass
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Dict, Any, List, Union
+
+from MCP_Server.plugin_aliases import (
+    get_alias_for_param,
+    get_categories,
+    resolve_alias,
+)
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, 
@@ -1694,8 +1705,6 @@ def get_device_parameters(
     Specify category or show_all=True for full parameter details.
     """
     try:
-        from MCP_Server.plugin_aliases import get_categories, get_alias_for_param
-
         ableton = get_ableton_connection()
         ti = _to_zero_based(track_index, "track_index")
         di = _to_zero_based(device_index, "device_index")
@@ -1784,8 +1793,6 @@ def set_device_parameter(
     - value: Normalized value 0.0-1.0.
     """
     try:
-        from MCP_Server.plugin_aliases import resolve_alias
-
         ableton = get_ableton_connection()
         ti = _to_zero_based(track_index, "track_index")
         di = _to_zero_based(device_index, "device_index")

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ This project includes several specialized components:
 
 - **[Installation Guide](INSTALLATION.md)** - Detailed setup instructions
 - **[User Guide](README.md)** - What, which, and how  
+- **[Live 11 Compatibility Notes](LIVE_11_NOTES.md)** - End-user behavior differences vs. Live 12
 
 ---
 

--- a/tests/unit/test_arrangement_commands.py
+++ b/tests/unit/test_arrangement_commands.py
@@ -290,6 +290,20 @@ class TestCreateArrangementMidiClipCommand:
 
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')
+    def test_passes_name_through(self, mock_conn, mock_ts):
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = {"overlapped_clips": []}
+        mock_conn.return_value = mock_ableton
+
+        from MCP_Server.server import create_arrangement_midi_clip
+        create_arrangement_midi_clip(
+            MagicMock(), track_index=1, start_bar=1, end_bar=5, name="Intro")
+
+        args = mock_ableton.send_command.call_args
+        assert args[0][1]["name"] == "Intro"
+
+    @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
+    @patch('MCP_Server.server.get_ableton_connection')
     def test_overlap_warning(self, mock_conn, mock_ts):
         # When the RS reports overlapped clips, the result should contain a warning
         mock_ableton = MagicMock()

--- a/tests/unit/test_arrangement_commands.py
+++ b/tests/unit/test_arrangement_commands.py
@@ -461,3 +461,51 @@ class TestManageClipAutomationCommand:
             MagicMock(), track_index=1, clip_index=1, action="clear_all")
 
         assert "Cleared all" in result
+
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_clip_name_forwarded_and_takes_precedence(self, mock_conn):
+        # clip_name must be forwarded; clip_index must NOT be sent so the
+        # Remote Script resolves by name unambiguously.
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = {"action": "create", "done": True}
+        mock_conn.return_value = mock_ableton
+
+        from MCP_Server.server import manage_clip_automation
+        manage_clip_automation(
+            MagicMock(), track_index=2, clip_index=4, clip_name="Lead",
+            action="create", parameter_name="volume")
+
+        payload = mock_ableton.send_command.call_args[0][1]
+        assert payload["clip_name"] == "Lead"
+        assert "clip_index" not in payload
+        assert payload["track_index"] == 1
+
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_remote_parameter_name_surfaces_in_message(self, mock_conn):
+        # Server must not fabricate the parameter — it should reflect what
+        # the Remote Script reports (e.g. "Track Volume" for an alias).
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = {
+            "action": "create", "parameter": "Track Volume", "done": True}
+        mock_conn.return_value = mock_ableton
+
+        from MCP_Server.server import manage_clip_automation
+        result = manage_clip_automation(
+            MagicMock(), track_index=1, clip_index=1,
+            action="create", parameter_name="volume")
+
+        assert "Track Volume" in result
+
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_zero_clip_index_without_name_errors(self, mock_conn):
+        # 0 violates the 1-based contract; reject before round-tripping.
+        mock_ableton = MagicMock()
+        mock_conn.return_value = mock_ableton
+
+        from MCP_Server.server import manage_clip_automation
+        result = manage_clip_automation(
+            MagicMock(), track_index=1, clip_index=0,
+            action="create", parameter_name="volume")
+
+        assert "Error" in result
+        mock_ableton.send_command.assert_not_called()

--- a/tests/unit/test_arrangement_commands.py
+++ b/tests/unit/test_arrangement_commands.py
@@ -175,6 +175,35 @@ class TestJumpToCuePointCommand:
         mock_ableton.send_command.assert_called_with(
             "jump_to_cue", {"name": "Verse"})
 
+    @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_response_does_not_leak_dict(self, mock_conn, mock_ts):
+        # Response must not be a string-formatted dict like "{'time': 16.0}"
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = {"direction": "next", "time": 16.0}
+        mock_conn.return_value = mock_ableton
+
+        from MCP_Server.server import jump_to_cue_point
+        result = jump_to_cue_point(MagicMock(), direction="next")
+
+        assert "{'" not in result and "}" not in result
+        assert "next" in result
+        assert "bar 5" in result  # beat 16 in 4/4 = bar 5
+
+    @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_response_includes_name_and_bar(self, mock_conn, mock_ts):
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = {"name": "Verse", "time": 8.0}
+        mock_conn.return_value = mock_ableton
+
+        from MCP_Server.server import jump_to_cue_point
+        result = jump_to_cue_point(MagicMock(), name="Verse")
+
+        assert "Verse" in result
+        assert "bar 3" in result  # beat 8 in 4/4 = bar 3
+        assert "{" not in result
+
 
 class TestCreateCuePointCommand:
     """Test create/delete cue point commands."""
@@ -238,6 +267,19 @@ class TestCreateCuePointCommand:
 
         assert "not applied" not in result
         assert "bar 5" in result
+
+    @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_create_without_bar_derives_bar_from_beat(self, mock_conn, mock_ts):
+        # Calling create_cue_point(beat=12.0) without bar should report bar 4
+        # (beat 12 in 4/4 = bar 4) instead of "at bar ?".
+        self._wire(mock_conn, [{"time": 12.0, "name": "1"}])
+
+        from MCP_Server.server import create_cue_point
+        result = create_cue_point(MagicMock(), beat=12.0)
+
+        assert "bar 4" in result
+        assert "?" not in result
 
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')

--- a/tests/unit/test_arrangement_commands.py
+++ b/tests/unit/test_arrangement_commands.py
@@ -255,15 +255,30 @@ class TestCreateCuePointCommand:
     @patch('MCP_Server.server.get_ableton_connection')
     def test_delete_at_bar(self, mock_conn, mock_ts):
         # Deleting a cue point at bar 5 should convert to beat 16.0
-        mock_ableton = MagicMock()
-        mock_ableton.send_command.return_value = {}
-        mock_conn.return_value = mock_ableton
+        mock_ableton = self._wire(mock_conn, [])  # readback sees no cue → success
 
         from MCP_Server.server import delete_cue_point
-        delete_cue_point(MagicMock(), bar=5)
+        result = delete_cue_point(MagicMock(), bar=5)
 
-        mock_ableton.send_command.assert_called_with(
+        mock_ableton.send_command.assert_any_call(
             "delete_cue_point", {"time": 16.0})
+        assert "Deleted" in result
+        assert "bar 5" in result
+
+    @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_delete_warns_when_readback_still_finds_cue(self, mock_conn, mock_ts):
+        # If the deferred set_or_delete_cue hasn't resolved (or it failed),
+        # the cue is still present after the retry budget. Surface that
+        # honestly rather than claiming success.
+        self._wire(mock_conn, [{"time": 16.0, "name": "1"}])
+
+        from MCP_Server.server import delete_cue_point
+        with patch('time.sleep'):  # skip retry sleeps
+            result = delete_cue_point(MagicMock(), bar=5)
+
+        assert "still" in result.lower()
+        assert "bar 5" in result
 
 
 class TestCreateArrangementMidiClipCommand:

--- a/tests/unit/test_arrangement_commands.py
+++ b/tests/unit/test_arrangement_commands.py
@@ -179,19 +179,77 @@ class TestJumpToCuePointCommand:
 class TestCreateCuePointCommand:
     """Test create/delete cue point commands."""
 
+    @staticmethod
+    def _wire(mock_conn, readback_cues):
+        mock_ableton = MagicMock()
+        def send(cmd, _params=None):
+            if cmd == "get_cue_points":
+                return {"cue_points": readback_cues}
+            return {}
+        mock_ableton.send_command.side_effect = send
+        mock_conn.return_value = mock_ableton
+        return mock_ableton
+
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')
-    def test_create_at_bar(self, mock_conn, mock_ts):
+    def test_create_at_bar_sends_correct_params(self, mock_conn, mock_ts):
         # Creating a cue point at bar 5 should convert to beat 16.0 and include the name
-        mock_ableton = MagicMock()
-        mock_ableton.send_command.return_value = {}
-        mock_conn.return_value = mock_ableton
+        mock_ableton = self._wire(mock_conn, [{"time": 16.0, "name": "Bridge"}])
 
         from MCP_Server.server import create_cue_point
         create_cue_point(MagicMock(), bar=5, name="Bridge")
 
-        mock_ableton.send_command.assert_called_with(
+        mock_ableton.send_command.assert_any_call(
             "create_cue_point", {"time": 16.0, "name": "Bridge"})
+
+    @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_response_uses_readback_name_when_applied(self, mock_conn, mock_ts):
+        self._wire(mock_conn, [{"time": 16.0, "name": "Bridge"}])
+
+        from MCP_Server.server import create_cue_point
+        result = create_cue_point(MagicMock(), bar=5, name="Bridge")
+
+        assert "Bridge" in result
+        assert "not applied" not in result
+        assert "bar 5" in result
+
+    @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_response_warns_when_name_not_applied(self, mock_conn, mock_ts):
+        # Live 11 returns the locator default name ("1") regardless of requested name.
+        self._wire(mock_conn, [{"time": 16.0, "name": "1"}])
+
+        from MCP_Server.server import create_cue_point
+        result = create_cue_point(MagicMock(), bar=5, name="Bridge")
+
+        assert "not applied" in result
+        assert "Bridge" in result
+        assert "'1'" in result
+        assert "bar 5" in result
+
+    @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_response_no_name_requested_uses_actual(self, mock_conn, mock_ts):
+        self._wire(mock_conn, [{"time": 16.0, "name": "1"}])
+
+        from MCP_Server.server import create_cue_point
+        result = create_cue_point(MagicMock(), bar=5, name="")
+
+        assert "not applied" not in result
+        assert "bar 5" in result
+
+    @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_falls_back_when_readback_finds_nothing(self, mock_conn, mock_ts):
+        # If the readback can't find the cue (race/failure), don't lie about state — fall back.
+        self._wire(mock_conn, [])
+
+        from MCP_Server.server import create_cue_point
+        result = create_cue_point(MagicMock(), bar=5, name="Bridge")
+
+        assert "bar 5" in result
+        # No false "name applied" claim and no false "not applied" claim either.
 
     @patch('MCP_Server.server._get_time_signature', return_value=(4, 4))
     @patch('MCP_Server.server.get_ableton_connection')

--- a/tests/unit/test_browser_path_normalization.py
+++ b/tests/unit/test_browser_path_normalization.py
@@ -126,6 +126,97 @@ def test_get_browser_items_at_path_normalizes_vst_alias_to_plugins():
     assert result["items"][0]["name"] == "MegaSynth"
 
 
+def test_get_browser_tree_recurses_into_folder_children():
+    # Tree should expose nested folders so callers can see structure, not just root.
+    bass = _FakeItem("Bass")
+    lead = _FakeItem("Lead")
+    operator = _FakeItem("Operator", children=[bass, lead])
+    analog = _FakeItem("Analog", is_device=True, is_loadable=True)
+    instruments = _FakeItem("Instruments", children=[analog, operator])
+    browser = types.SimpleNamespace(
+        instruments=instruments,
+        sounds=_FakeItem("Sounds"),
+        drums=_FakeItem("Drums"),
+        audio_effects=_FakeItem("Audio Effects"),
+        midi_effects=_FakeItem("MIDI Effects"),
+    )
+    surface = _make_surface_with_browser(browser)
+
+    result = surface.get_browser_tree("instruments")
+
+    categories = result["categories"]
+    assert len(categories) == 1
+    root = categories[0]
+    assert root["name"] == "Instruments"
+    child_names = sorted(c["name"] for c in root["children"])
+    assert child_names == ["Analog", "Operator"]
+    operator_node = next(c for c in root["children"] if c["name"] == "Operator")
+    grandchild_names = sorted(c["name"] for c in operator_node["children"])
+    assert grandchild_names == ["Bass", "Lead"]
+
+
+def test_get_browser_tree_reports_total_folder_count():
+    # total_folders should reflect every folder node visited in the tree.
+    bass_presets = _FakeItem("Bass", children=[_FakeItem("Sub.adv", is_loadable=True)])
+    operator = _FakeItem("Operator", children=[bass_presets])
+    instruments = _FakeItem("Instruments", children=[operator, _FakeItem("Analog")])
+    browser = types.SimpleNamespace(
+        instruments=instruments,
+        sounds=_FakeItem("Sounds"),
+        drums=_FakeItem("Drums"),
+        audio_effects=_FakeItem("Audio Effects"),
+        midi_effects=_FakeItem("MIDI Effects"),
+    )
+    surface = _make_surface_with_browser(browser)
+
+    result = surface.get_browser_tree("instruments")
+
+    # Three folder nodes: Instruments, Operator, Bass. Analog and Sub.adv are leaves.
+    assert result["total_folders"] == 3
+
+
+def test_get_browser_tree_includes_navigable_path_per_node():
+    # Tree paths must be usable as input to get_browser_items_at_path.
+    bass = _FakeItem("Bass")
+    operator = _FakeItem("Operator", children=[bass])
+    instruments = _FakeItem("Instruments", children=[operator])
+    browser = types.SimpleNamespace(
+        instruments=instruments,
+        sounds=_FakeItem("Sounds"),
+        drums=_FakeItem("Drums"),
+        audio_effects=_FakeItem("Audio Effects"),
+        midi_effects=_FakeItem("MIDI Effects"),
+    )
+    surface = _make_surface_with_browser(browser)
+
+    result = surface.get_browser_tree("instruments")
+    operator_node = result["categories"][0]["children"][0]
+    bass_node = operator_node["children"][0]
+
+    assert operator_node["path"] == "Instruments/Operator"
+    assert bass_node["path"] == "Instruments/Operator/Bass"
+
+
+def test_get_browser_tree_caps_children_and_marks_has_more():
+    # Drums has hundreds of leaf children. Tree must cap and signal truncation.
+    many = [_FakeItem("Kit{0}.adg".format(i), is_loadable=True) for i in range(50)]
+    drums = _FakeItem("Drums", children=many)
+    browser = types.SimpleNamespace(
+        instruments=_FakeItem("Instruments"),
+        sounds=_FakeItem("Sounds"),
+        drums=drums,
+        audio_effects=_FakeItem("Audio Effects"),
+        midi_effects=_FakeItem("MIDI Effects"),
+    )
+    surface = _make_surface_with_browser(browser)
+
+    result = surface.get_browser_tree("drums")
+    drums_node = result["categories"][0]
+
+    assert drums_node["has_more"] is True
+    assert len(drums_node["children"]) < 50
+
+
 def test_get_browser_items_at_path_unknown_category_error_is_normalized():
     browser = types.SimpleNamespace(
         instruments=_FakeItem("Instruments"),

--- a/tests/unit/test_device_commands.py
+++ b/tests/unit/test_device_commands.py
@@ -91,6 +91,35 @@ class TestGetDeviceParameters:
         call_args = mock_ableton.send_command.call_args
         assert call_args[0][1]["chain_index"] == 1  # 2 - 1
 
+    @patch('MCP_Server.server.get_categories', return_value={})
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_summary_drops_bucket_when_only_one_category(self, mock_conn, _mock_cats):
+        # When categorization yields one bucket (e.g. all "Other" because the
+        # device has no defined prefixes), don't print "Other: N parameters" —
+        # it's noise. Drop it and just point at show_all.
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = {
+            "device_name": "Operator",
+            "device_class": "Operator",
+            "parameter_count": 3,
+            "parameters": [
+                {"index": 0, "name": "Foo", "value": 0.0, "min": 0.0, "max": 1.0,
+                 "display_value": "0", "is_enabled": True, "is_quantized": False,
+                 "value_items": []},
+                {"index": 1, "name": "Bar", "value": 0.0, "min": 0.0, "max": 1.0,
+                 "display_value": "0", "is_enabled": True, "is_quantized": False,
+                 "value_items": []},
+                {"index": 2, "name": "Baz", "value": 0.0, "min": 0.0, "max": 1.0,
+                 "display_value": "0", "is_enabled": True, "is_quantized": False,
+                 "value_items": []},
+            ],
+        }
+        mock_conn.return_value = mock_ableton
+
+        result = get_device_parameters(MagicMock(), track_index=1)
+        assert "Other:" not in result
+        assert "show_all=True" in result
+
 
 class TestSetDeviceParameter:
     """Test set_device_parameter tool."""
@@ -157,6 +186,17 @@ class TestSetDeviceParameter:
         second_call = mock_ableton.send_command.call_args_list[1]
         assert second_call[0][1]["parameter_name"] == "Osc A WT Pos"
         assert "alias" in result
+
+    def test_value_is_required(self):
+        # Calling without value should fail with TypeError — guards against
+        # silent default-to-0.0 when an LLM uses a synonym like
+        # ``normalized_value=`` and the unknown kwarg gets dropped.
+        try:
+            set_device_parameter(MagicMock(), track_index=1, parameter_index=5)
+        except TypeError as e:
+            assert "value" in str(e).lower()
+        else:
+            raise AssertionError("expected TypeError when 'value' is omitted")
 
 
 class TestEnableDisableDevice:

--- a/tests/unit/test_load_drum_kit.py
+++ b/tests/unit/test_load_drum_kit.py
@@ -1,0 +1,159 @@
+"""Unit tests for the load_drum_kit MCP tool."""
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+
+_mock_mcp_module = MagicMock()
+_mock_fastmcp = MagicMock()
+_mock_fastmcp.FastMCP.return_value.tool.return_value = lambda fn: fn
+sys.modules["mcp"] = _mock_mcp_module
+sys.modules["mcp.server"] = MagicMock()
+sys.modules["mcp.server.fastmcp"] = _mock_fastmcp
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from MCP_Server.server import load_drum_kit  # noqa: E402
+
+
+@patch("MCP_Server.server.get_ableton_connection")
+def test_loads_kit_when_path_resolves_directly_to_loadable_file(mock_conn):
+    # Stock Ableton kits live as .adg files directly under drums/, with no children.
+    # The tool must accept a path that resolves to such a leaf and load it.
+    mock_ableton = MagicMock()
+
+    def side_effect(command, params=None):
+        if command == "load_browser_item":
+            return {"loaded": True}
+        if command == "get_browser_items_at_path":
+            return {
+                "path": params["path"],
+                "name": "808 Core Kit.adg",
+                "uri": "query:Drums#FileId_4197",
+                "is_folder": False,
+                "is_loadable": True,
+                "items": [],
+            }
+        raise AssertionError("unexpected command: {0}".format(command))
+
+    mock_ableton.send_command.side_effect = side_effect
+    mock_conn.return_value = mock_ableton
+
+    result = load_drum_kit(
+        MagicMock(),
+        track_index=1,
+        rack_uri="query:Drums#Drum%20Rack",
+        kit_path="drums/808 Core Kit.adg",
+    )
+
+    assert "808 Core Kit.adg" in result
+    load_calls = [
+        call for call in mock_ableton.send_command.call_args_list
+        if call.args[0] == "load_browser_item"
+    ]
+    # First load = drum rack. Second load = the resolved kit URI.
+    assert len(load_calls) == 2
+    assert load_calls[1].args[1]["item_uri"] == "query:Drums#FileId_4197"
+
+
+@patch("MCP_Server.server.get_ableton_connection")
+def test_accepts_kit_uri_directly_consistent_with_load_instrument(mock_conn):
+    # Mirroring load_instrument_or_effect, kit_path may be a browser URI.
+    # When given a URI, no path resolution should be attempted.
+    mock_ableton = MagicMock()
+
+    def side_effect(command, params=None):
+        if command == "load_browser_item":
+            return {"loaded": True}
+        if command == "get_browser_items_at_path":
+            raise AssertionError("URI form should not call get_browser_items_at_path")
+        raise AssertionError("unexpected command: {0}".format(command))
+
+    mock_ableton.send_command.side_effect = side_effect
+    mock_conn.return_value = mock_ableton
+
+    result = load_drum_kit(
+        MagicMock(),
+        track_index=1,
+        rack_uri="query:Drums#Drum%20Rack",
+        kit_path="query:Drums#FileId_4197",
+    )
+
+    assert "track 1" in result
+    load_calls = [
+        call for call in mock_ableton.send_command.call_args_list
+        if call.args[0] == "load_browser_item"
+    ]
+    assert load_calls[1].args[1]["item_uri"] == "query:Drums#FileId_4197"
+
+
+@patch("MCP_Server.server.get_ableton_connection")
+def test_falls_back_to_first_loadable_child_for_folder_paths(mock_conn):
+    # When the path resolves to a folder, pick the first loadable child as before.
+    mock_ableton = MagicMock()
+
+    def side_effect(command, params=None):
+        if command == "load_browser_item":
+            return {"loaded": True}
+        if command == "get_browser_items_at_path":
+            return {
+                "path": params["path"],
+                "name": "Custom",
+                "uri": "user-library:Drum Kits#Custom",
+                "is_folder": True,
+                "is_loadable": False,
+                "items": [
+                    {"name": "MyKit.adg", "is_loadable": True, "uri": "user-library:Drum Kits#MyKit"},
+                ],
+            }
+        raise AssertionError("unexpected command: {0}".format(command))
+
+    mock_ableton.send_command.side_effect = side_effect
+    mock_conn.return_value = mock_ableton
+
+    result = load_drum_kit(
+        MagicMock(),
+        track_index=2,
+        rack_uri="query:Drums#Drum%20Rack",
+        kit_path="user-library/Drum Kits/Custom",
+    )
+
+    assert "MyKit.adg" in result
+    load_calls = [
+        call for call in mock_ableton.send_command.call_args_list
+        if call.args[0] == "load_browser_item"
+    ]
+    assert load_calls[1].args[1]["item_uri"] == "user-library:Drum Kits#MyKit"
+
+
+@patch("MCP_Server.server.get_ableton_connection")
+def test_reports_failure_when_path_is_unloadable_folder(mock_conn):
+    # Resolving to a folder with no loadable children must surface an error,
+    # not silently no-op after loading the rack.
+    mock_ableton = MagicMock()
+
+    def side_effect(command, params=None):
+        if command == "load_browser_item":
+            return {"loaded": True}
+        if command == "get_browser_items_at_path":
+            return {
+                "path": params["path"],
+                "name": "Empty",
+                "uri": None,
+                "is_folder": True,
+                "is_loadable": False,
+                "items": [],
+            }
+        raise AssertionError("unexpected command: {0}".format(command))
+
+    mock_ableton.send_command.side_effect = side_effect
+    mock_conn.return_value = mock_ableton
+
+    result = load_drum_kit(
+        MagicMock(),
+        track_index=1,
+        rack_uri="query:Drums#Drum%20Rack",
+        kit_path="drums/Empty",
+    )
+
+    assert "no loadable" in result.lower()

--- a/tests/unit/test_remote_script_helpers.py
+++ b/tests/unit/test_remote_script_helpers.py
@@ -381,3 +381,20 @@ class TestCreateArrangementClipLive11Fallback:
             raise AssertionError("expected an error when no empty slot is available")
 
         track.duplicate_clip_to_arrangement.assert_not_called()
+
+
+class TestArrangementClipRejectsInvalidTracks:
+    """_validate_not_return_or_master also blocks group tracks; otherwise the
+    Live 11 fallback would iterate clip_slots to no avail and the Live 12
+    create_midi_clip call would fail at the API boundary."""
+
+    def test_rejects_group_track(self):
+        group = _GroupTrack("Mix Bus")
+        script = _make_script([group])
+
+        try:
+            script._create_arrangement_clip(track_index=0, position=0.0, length=4.0)
+        except ValueError as e:
+            assert "group" in str(e).lower()
+        else:
+            raise AssertionError("expected ValueError for group track")

--- a/tests/unit/test_remote_script_helpers.py
+++ b/tests/unit/test_remote_script_helpers.py
@@ -130,6 +130,7 @@ class TestCreateCuePointAssignsName:
     @staticmethod
     def _wire_toggle(script, returned_cue):
         script._song.cue_points = ()
+        script.schedule_message = MagicMock(side_effect=lambda _delay, fn: fn())
 
         def toggle():
             script._song.cue_points = (returned_cue,)
@@ -157,3 +158,83 @@ class TestCreateCuePointAssignsName:
         script._create_cue_point(time=16.0, name="")
 
         assert cue.name == "1.1.1"
+
+
+def _make_cue(time, name):
+    cue = MagicMock()
+    cue.time = time
+    cue.name = name
+    return cue
+
+
+class TestGetCuePoints:
+    def test_returns_all_cues(self):
+        script = _make_script()
+        script._song.cue_points = (
+            _make_cue(0.0, "Intro"),
+            _make_cue(32.0, "Drop"),
+        )
+
+        result = script._get_cue_points()
+
+        assert result == {"cue_points": [
+            {"name": "Intro", "time": 0.0},
+            {"name": "Drop", "time": 32.0},
+        ]}
+
+    def test_empty_when_no_cues(self):
+        script = _make_script()
+        script._song.cue_points = ()
+
+        assert script._get_cue_points() == {"cue_points": []}
+
+
+class TestJumpToCueByName:
+    def test_jumps_to_named_cue(self):
+        script = _make_script()
+        drop = _make_cue(32.0, "Drop")
+        script._song.cue_points = (_make_cue(0.0, "Intro"), drop)
+
+        result = script._jump_to_cue(name="Drop")
+
+        drop.jump.assert_called_once_with()
+        assert result == {"name": "Drop", "time": 32.0}
+
+    def test_raises_when_name_not_found(self):
+        script = _make_script()
+        script._song.cue_points = (_make_cue(0.0, "Intro"),)
+
+        try:
+            script._jump_to_cue(name="Nope")
+        except ValueError as e:
+            assert "Nope" in str(e)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestDeleteCuePoint:
+    def test_deletes_cue_at_time(self):
+        script = _make_script()
+        script._song.cue_points = (
+            _make_cue(0.0, "Intro"),
+            _make_cue(32.0, "Drop"),
+        )
+        script.schedule_message = MagicMock(side_effect=lambda _delay, fn: fn())
+
+        result = script._delete_cue_point(time=32.0)
+
+        assert script._song.current_song_time == 32.0
+        script._song.set_or_delete_cue.assert_called_once_with()
+        assert result == {"deleted": True}
+
+    def test_raises_when_no_cue_at_time(self):
+        script = _make_script()
+        script._song.cue_points = (_make_cue(0.0, "Intro"),)
+
+        try:
+            script._delete_cue_point(time=32.0)
+        except ValueError as e:
+            assert "No cue point" in str(e)
+        else:
+            raise AssertionError("expected ValueError")
+        script._song.set_or_delete_cue.assert_not_called()

--- a/tests/unit/test_remote_script_helpers.py
+++ b/tests/unit/test_remote_script_helpers.py
@@ -71,6 +71,7 @@ class _GroupTrack:
 
 def _make_script(tracks=()):
     script = AbletonMCP.__new__(AbletonMCP)
+    script.log_message = lambda _msg: None
     script._song = MagicMock()
     script._song.tracks = list(tracks)
     script._song.return_tracks = []
@@ -238,3 +239,120 @@ class TestDeleteCuePoint:
         else:
             raise AssertionError("expected ValueError")
         script._song.set_or_delete_cue.assert_not_called()
+
+
+class _Live12Track(_NormalTrack):
+    """Live 12 exposes create_midi_clip(start_time, length) on Track."""
+
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.create_midi_clip = MagicMock()
+
+
+class _Live11Track(_NormalTrack):
+    """Live 11 has no create_midi_clip on Track — must round-trip through a slot."""
+
+    def __init__(self, slots=None, **kw):
+        super().__init__(**kw)
+        self.clip_slots = list(slots or [])
+        self.duplicate_clip_to_arrangement = MagicMock()
+
+
+def _empty_slot():
+    slot = MagicMock()
+    slot.has_clip = False
+    new_clip = MagicMock()
+
+    def _create(length):
+        slot.has_clip = True
+        slot.clip = new_clip
+
+    def _delete():
+        slot.has_clip = False
+        slot.clip = None
+
+    slot.create_clip.side_effect = _create
+    slot.delete_clip.side_effect = _delete
+    return slot, new_clip
+
+
+def _full_slot():
+    slot = MagicMock()
+    slot.has_clip = True
+    return slot
+
+
+class TestCreateArrangementClipLive12:
+    def test_calls_create_midi_clip_with_start_and_length(self):
+        track = _Live12Track()
+        script = _make_script([track])
+
+        script._create_arrangement_clip(track_index=0, position=8.0, length=16.0)
+
+        track.create_midi_clip.assert_called_once_with(8.0, 16.0)
+
+    def test_assigns_name_to_new_clip(self):
+        track = _Live12Track()
+        new_clip = MagicMock()
+        new_clip.start_time = 8.0
+        new_clip.end_time = 12.0
+        track.create_midi_clip.return_value = new_clip
+        script = _make_script([track])
+
+        script._create_arrangement_clip(
+            track_index=0, position=8.0, length=4.0, name="Intro")
+
+        assert new_clip.name == "Intro"
+
+    def test_blank_name_does_not_overwrite(self):
+        track = _Live12Track()
+        new_clip = MagicMock()
+        new_clip.start_time = 0.0
+        new_clip.end_time = 4.0
+        new_clip.name = "Original"
+        track.create_midi_clip.return_value = new_clip
+        script = _make_script([track])
+
+        script._create_arrangement_clip(
+            track_index=0, position=0.0, length=4.0, name="")
+
+        assert new_clip.name == "Original"
+
+
+class TestCreateArrangementClipLive11Fallback:
+    def test_round_trips_through_empty_session_slot(self):
+        empty, new_clip = _empty_slot()
+        track = _Live11Track(slots=[_full_slot(), empty])
+        script = _make_script([track])
+
+        script._create_arrangement_clip(track_index=0, position=8.0, length=4.0)
+
+        empty.create_clip.assert_called_once_with(4.0)
+        track.duplicate_clip_to_arrangement.assert_called_once_with(new_clip, 8.0)
+        empty.delete_clip.assert_called_once_with()
+
+    def test_cleans_up_session_clip_when_duplicate_fails(self):
+        empty, _ = _empty_slot()
+        track = _Live11Track(slots=[empty])
+        track.duplicate_clip_to_arrangement.side_effect = RuntimeError("boom")
+        script = _make_script([track])
+
+        try:
+            script._create_arrangement_clip(track_index=0, position=0.0, length=4.0)
+        except RuntimeError:
+            pass
+
+        empty.delete_clip.assert_called_once_with()
+
+    def test_raises_when_no_empty_slot(self):
+        track = _Live11Track(slots=[_full_slot(), _full_slot()])
+        script = _make_script([track])
+
+        try:
+            script._create_arrangement_clip(track_index=0, position=0.0, length=4.0)
+        except Exception as e:
+            assert "empty" in str(e).lower() or "slot" in str(e).lower()
+        else:
+            raise AssertionError("expected an error when no empty slot is available")
+
+        track.duplicate_clip_to_arrangement.assert_not_called()

--- a/tests/unit/test_remote_script_helpers.py
+++ b/tests/unit/test_remote_script_helpers.py
@@ -282,6 +282,13 @@ def _full_slot():
     return slot
 
 
+def _wire_live12_create(track, new_clip):
+    """Make track.create_midi_clip() append new_clip to arrangement_clips,
+    matching Live 12's actual side effect."""
+    track.create_midi_clip.side_effect = (
+        lambda *_: track.arrangement_clips.append(new_clip))
+
+
 class TestCreateArrangementClipLive12:
     def test_calls_create_midi_clip_with_start_and_length(self):
         track = _Live12Track()
@@ -296,7 +303,7 @@ class TestCreateArrangementClipLive12:
         new_clip = MagicMock()
         new_clip.start_time = 8.0
         new_clip.end_time = 12.0
-        track.create_midi_clip.return_value = new_clip
+        _wire_live12_create(track, new_clip)
         script = _make_script([track])
 
         script._create_arrangement_clip(
@@ -310,13 +317,31 @@ class TestCreateArrangementClipLive12:
         new_clip.start_time = 0.0
         new_clip.end_time = 4.0
         new_clip.name = "Original"
-        track.create_midi_clip.return_value = new_clip
+        _wire_live12_create(track, new_clip)
         script = _make_script([track])
 
         script._create_arrangement_clip(
             track_index=0, position=0.0, length=4.0, name="")
 
         assert new_clip.name == "Original"
+
+    def test_finds_clip_via_scan_when_create_returns_none(self):
+        track = _Live12Track()
+        new_clip = MagicMock()
+        new_clip.start_time = 4.0
+        new_clip.end_time = 8.0
+        # Live 12's create_midi_clip return value is unspecified by the LOM —
+        # explicitly return None and confirm the scan still picks up the clip.
+        def _create(*_):
+            track.arrangement_clips.append(new_clip)
+            return None
+        track.create_midi_clip.side_effect = _create
+        script = _make_script([track])
+
+        script._create_arrangement_clip(
+            track_index=0, position=4.0, length=4.0, name="Verse")
+
+        assert new_clip.name == "Verse"
 
 
 class TestCreateArrangementClipLive11Fallback:

--- a/tests/unit/test_script_mode_imports.py
+++ b/tests/unit/test_script_mode_imports.py
@@ -1,0 +1,95 @@
+"""Regression: server.py must work when launched as `python /path/to/server.py`.
+
+Claude Desktop's MCP launcher invokes the server by absolute script path, which
+puts only the script's directory on sys.path — the parent `MCP_Server` package
+is not importable that way, so any `from MCP_Server.X import Y` inside a tool
+handler must be resilient to that layout.
+"""
+import os
+import subprocess
+import sys
+import textwrap
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+PKG_DIR = os.path.join(REPO_ROOT, "MCP_Server")
+SERVER_PATH = os.path.join(PKG_DIR, "server.py")
+
+
+def _run_in_script_mode(snippet: str) -> subprocess.CompletedProcess:
+    bootstrap = textwrap.dedent(
+        f"""
+        import sys
+        from unittest.mock import MagicMock
+        sys.modules['mcp'] = MagicMock()
+        sys.modules['mcp.server'] = MagicMock()
+        fastmcp = MagicMock()
+        fastmcp.FastMCP.return_value.tool.return_value = lambda fn: fn
+        sys.modules['mcp.server.fastmcp'] = fastmcp
+
+        sys.path = [p for p in sys.path if p not in ('', {REPO_ROOT!r})]
+        sys.path.insert(0, {PKG_DIR!r})
+
+        import importlib.util
+        spec = importlib.util.spec_from_file_location('server', {SERVER_PATH!r})
+        server = importlib.util.module_from_spec(spec)
+        sys.modules['server'] = server
+        spec.loader.exec_module(server)
+        """
+    )
+    return subprocess.run(
+        [sys.executable, "-c", bootstrap + "\n" + snippet],
+        capture_output=True,
+        text=True,
+        cwd="/",
+    )
+
+
+def test_get_device_parameters_does_not_crash_on_lazy_import():
+    snippet = textwrap.dedent(
+        """
+        from unittest.mock import MagicMock
+        ableton = MagicMock()
+        ableton.send_command.return_value = {
+            'device_name': 'Pro-Q 3',
+            'device_class': 'PluginDevice',
+            'parameter_count': 1,
+            'parameters': [{
+                'index': 0, 'name': 'Output Gain', 'value': 0.5,
+                'min': 0.0, 'max': 1.0, 'display_value': '0 dB',
+                'is_enabled': True, 'is_quantized': False, 'value_items': [],
+            }],
+        }
+        server.get_ableton_connection = lambda: ableton
+        out = server.get_device_parameters(MagicMock(), track_index=2, device_index=2)
+        print(out)
+        """
+    )
+    proc = _run_in_script_mode(snippet)
+    assert proc.returncode == 0, proc.stderr
+    assert "No module named" not in proc.stdout, proc.stdout
+    assert "Pro-Q 3" in proc.stdout
+
+
+def test_set_device_parameter_does_not_crash_on_lazy_import():
+    snippet = textwrap.dedent(
+        """
+        from unittest.mock import MagicMock
+        ableton = MagicMock()
+        ableton.send_command.side_effect = [
+            {'device_name': 'Pro-Q 3'},
+            {'parameter_name': 'Output Gain', 'display_value': '0 dB',
+             'new_value': 0.5, 'clamped': False},
+        ]
+        server.get_ableton_connection = lambda: ableton
+        out = server.set_device_parameter(
+            MagicMock(), track_index=2, device_index=2,
+            parameter_name='Output Gain', value=0.5,
+        )
+        print(out)
+        """
+    )
+    proc = _run_in_script_mode(snippet)
+    assert proc.returncode == 0, proc.stderr
+    assert "No module named" not in proc.stdout, proc.stdout
+    assert "Output Gain" in proc.stdout

--- a/tests/unit/test_track_commands.py
+++ b/tests/unit/test_track_commands.py
@@ -13,7 +13,14 @@ sys.modules['mcp.server.fastmcp'] = _mock_fastmcp
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
-from MCP_Server.server import delete_track, get_track_deletion_status
+import json
+
+from MCP_Server.server import (
+    delete_track,
+    get_track_deletion_status,
+    get_track_info,
+    load_instrument_or_effect,
+)
 
 
 class TestDeleteTrackSafetyGuard:
@@ -106,3 +113,69 @@ class TestTrackDeletionStatus:
 
         assert "Track deletion available" in result
         assert "up to 3 more track(s)" in result
+
+
+class TestGetTrackInfoOneBasedResponse:
+    """get_track_info exposes 1-based indices to match its 1-based parameter."""
+
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_top_level_and_nested_indices_are_one_based(self, mock_conn):
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = {
+            "index": 4,
+            "name": "5-Operator",
+            "is_audio_track": False,
+            "is_midi_track": True,
+            "is_group_track": False,
+            "clip_slots": [
+                {"index": 0, "has_clip": False, "clip": None},
+                {"index": 1, "has_clip": False, "clip": None},
+            ],
+            "devices": [
+                {"index": 0, "name": "Operator", "class_name": "Operator", "type": "unknown"},
+                {"index": 1, "name": "EQ Eight", "class_name": "Eq8", "type": "unknown"},
+            ],
+        }
+        mock_conn.return_value = mock_ableton
+
+        result = json.loads(get_track_info(MagicMock(), track_index=5))
+
+        assert result["index"] == 5
+        assert [s["index"] for s in result["clip_slots"]] == [1, 2]
+        assert [d["index"] for d in result["devices"]] == [1, 2]
+
+
+class TestLoadInstrumentOrEffectMessage:
+    """Success message must not end with an empty 'Devices on track:' fragment."""
+
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_uses_devices_after_when_remote_script_returns_them(self, mock_conn):
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = {
+            "loaded": True,
+            "item_name": "Operator",
+            "devices_after": ["Operator"],
+            "new_devices": ["Operator"],
+        }
+        mock_conn.return_value = mock_ableton
+
+        result = load_instrument_or_effect(
+            MagicMock(), track_index=5, uri="query:Synths#Operator")
+
+        assert "New devices: Operator" in result
+
+    @patch('MCP_Server.server.get_ableton_connection')
+    def test_falls_back_to_item_name_when_devices_missing(self, mock_conn):
+        mock_ableton = MagicMock()
+        mock_ableton.send_command.return_value = {
+            "loaded": True,
+            "item_name": "Operator",
+        }
+        mock_conn.return_value = mock_ableton
+
+        result = load_instrument_or_effect(
+            MagicMock(), track_index=5, uri="query:Synths#Operator")
+
+        assert "Operator" in result
+        assert not result.rstrip().endswith(":")
+        assert "Devices on track: " not in result


### PR DESCRIPTION
This PR bundles fixes for Live 11 users who currently hit broken tools or misleading responses across the Remote Script and MCP server. Every fix was validated end-to-end against a running Live 11.3.43 install. Live 12 paths were preserved and reviewed against the official LOM.

The diff is large but most of it is tests and docs:

```
Production code:  +422 / -183   across 2 files
Tests:            +887 / -11    across 7 files
Documentation:    +22 / -0      across 2 files
```

## What this fixes for Live 11 users

- **Cue points** — create/delete actually work (was silently toggling at beat 0), lookups find existing cues, and the response honestly reports what Live saved. Live 11's API doesn't allow setting `CuePoint.name`, so cues get auto-generated locator names — the wrapper surfaces those instead of pretending the requested name applied.
- **Arrangement MIDI clips** — `create_arrangement_midi_clip` works on Live 11 (the underlying `Track.create_midi_clip` is Live-12-only; the Live 11 path stages via session view).
- **Device parameter access** — `get_device_parameters` and `set_device_parameter` no longer ImportError when launched the way the README documents.
- **Browser tools** — `get_browser_tree` returns the requested subtree (was reporting "0 folders"), and `load_drum_kit` accepts browser URIs and finds stock kits.
- **Tool-surface polish** — `manage_clip_automation` resolves session clips consistently, `load_instrument_or_effect` lists what it loaded, `get_track_info` indices match the 1-based parameter contract, `jump_to_cue_point` formats its response cleanly, `set_device_parameter` schema rejects calls missing `value` instead of silently setting it to 0, plus several smaller papercuts.

## What's NOT in this PR

- No new tools or features.
- No changes to the wire protocol between MCP server and Remote Script.
- No refactoring of unrelated code.

## Live 12 safety

Version-sensitive paths use feature detection at runtime rather than version branching, so Live 12 takes the same fast path as before.

## Testing

- 184 unit tests, all passing.
- Each fix validated end-to-end against a running Live 11.3.43 install.

## Documentation

Adds `LIVE_11_NOTES.md` (linked from the README) for the two user-visible behavior differences on Live 11: cue-point names being read-only, and arrangement MIDI clip creation needing a free session-clip slot.