### PR TITLE
fix: remove AbletonMCP_UDP from packages — directory does not exist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["MCP_Server", "elevenlabs_mcp", "AbletonMCP_UDP"]
+packages = ["MCP_Server", "elevenlabs_mcp"]
 
 [project.urls]
 "Homepage" = "https://github.com/uisato/ableton-mcp-extended"


### PR DESCRIPTION
## What this fixes

Closes #22 — `pip install -e .` fails with:

```
error: package directory 'AbletonMCP_UDP' does not exist
```

## Root cause

`pyproject.toml` listed `AbletonMCP_UDP` as a package in `[tool.setuptools]`, but that directory doesn't exist anywhere in the repository. setuptools treats this as a hard error and aborts the build — meaning **no one can install this package** via pip or uv without hitting this crash first.

## Fix

Remove `AbletonMCP_UDP` from the `packages` list. One line change.

```toml
# Before
packages = ["MCP_Server", "elevenlabs_mcp", "AbletonMCP_UDP"]

# After
packages = ["MCP_Server", "elevenlabs_mcp"]
```

## Tested

Verified `pip install -e .` and `uv pip install -e .` both complete successfully after this change on macOS (Python 3.10.20).