### PR TITLE
feat(config): support ABLETON_HOST and ABLETON_PORT env vars

### DIFF
--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -3,6 +3,7 @@ from mcp.server.fastmcp import FastMCP, Context
 import socket
 import json
 import logging
+import os
 import re
 import threading
 import time
@@ -341,7 +342,10 @@ def get_ableton_connection():
         for attempt in range(1, max_attempts + 1):
             try:
                 logger.info(f"Connecting to Ableton (attempt {attempt}/{max_attempts})...")
-                _ableton_connection = AbletonConnection(host="localhost", port=9877)
+                _ableton_connection = AbletonConnection(
+                    host=os.getenv("ABLETON_HOST", "localhost"),
+                    port=int(os.getenv("ABLETON_PORT", "9877")),
+                )
                 if _ableton_connection.connect():
                     logger.info("Created new persistent connection to Ableton")
                     

--- a/tests/unit/test_connection_config.py
+++ b/tests/unit/test_connection_config.py
@@ -1,0 +1,50 @@
+"""Tests for ABLETON_HOST / ABLETON_PORT env-var configuration."""
+
+import importlib
+import os
+from unittest import mock
+
+
+def _reload_server_module():
+    import MCP_Server.server as server  # noqa: WPS433 (import in function for reload)
+
+    return importlib.reload(server)
+
+
+def test_get_ableton_connection_uses_default_host_and_port_when_env_unset():
+    """When no env vars are set, AbletonConnection should be constructed with localhost:9877."""
+    env_without_overrides = {
+        k: v for k, v in os.environ.items() if k not in {"ABLETON_HOST", "ABLETON_PORT"}
+    }
+    with mock.patch.dict(os.environ, env_without_overrides, clear=True):
+        server = _reload_server_module()
+        with mock.patch.object(server, "_ableton_connection", None):
+            with mock.patch.object(server, "AbletonConnection") as mock_cls:
+                mock_cls.return_value.connect.return_value = True
+                server.get_ableton_connection()
+                mock_cls.assert_called_with(host="localhost", port=9877)
+
+
+def test_get_ableton_connection_uses_env_host_and_port_when_set():
+    """When ABLETON_HOST / ABLETON_PORT are set, AbletonConnection should pick them up."""
+    overrides = {"ABLETON_HOST": "live-host.example.com", "ABLETON_PORT": "12345"}
+    with mock.patch.dict(os.environ, overrides, clear=False):
+        server = _reload_server_module()
+        with mock.patch.object(server, "_ableton_connection", None):
+            with mock.patch.object(server, "AbletonConnection") as mock_cls:
+                mock_cls.return_value.connect.return_value = True
+                server.get_ableton_connection()
+                mock_cls.assert_called_with(host="live-host.example.com", port=12345)
+
+
+def test_ableton_port_env_is_coerced_to_int():
+    """ABLETON_PORT is a string env var; it must be coerced to int for AbletonConnection."""
+    with mock.patch.dict(os.environ, {"ABLETON_PORT": "8765"}, clear=False):
+        server = _reload_server_module()
+        with mock.patch.object(server, "_ableton_connection", None):
+            with mock.patch.object(server, "AbletonConnection") as mock_cls:
+                mock_cls.return_value.connect.return_value = True
+                server.get_ableton_connection()
+                args, kwargs = mock_cls.call_args
+                assert isinstance(kwargs["port"], int)
+                assert kwargs["port"] == 8765


### PR DESCRIPTION
Allow the AbletonConnection host and port to be overridden via environment variables, with backward-compatible defaults (localhost:9877). This enables containerized deployments where the Ableton Live host differs from the MCP server host,  e.g. ABLETON_HOST=host.docker.internal to reach Live on the macOS host from a Linux container, without breaking existing setups.

- Add 'import os' to MCP_Server/server.py
- AbletonConnection now reads ABLETON_HOST and ABLETON_PORT with defaults
- ABLETON_PORT is coerced from string env var to int
- Add 3 unit tests covering default, override, and int-coercion behavior

Tests: tests/unit/test_connection_config.py — 3 passing, no regressions.