### PR TITLE
Fix editable install: map AbletonMCP_UDP to its real directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 packages = ["MCP_Server", "elevenlabs_mcp", "AbletonMCP_UDP"]
 
+[tool.setuptools.package-dir]
+AbletonMCP_UDP = "Ableton-MCP_hybrid-server/AbletonMCP_UDP"
+
 [project.urls]
 "Homepage" = "https://github.com/uisato/ableton-mcp-extended"
 "Bug Tracker" = "https://github.com/uisato/ableton-mcp-extended/issues"


### PR DESCRIPTION
## Problem

`pip install -e .` fails out of the box:

```
error: package directory 'AbletonMCP_UDP' does not exist
```

`pyproject.toml` lists `AbletonMCP_UDP` in `[tool.setuptools].packages` as if it were a top-level package, but it actually lives at `Ableton-MCP_hybrid-server/AbletonMCP_UDP/`. setuptools can't find it, so the editable build backend errors out before anything installs.

## Fix

Add a `[tool.setuptools.package-dir]` mapping pointing `AbletonMCP_UDP` at its real location. This preserves the existing intent (the package is still installed) while letting setuptools locate it.

```toml
[tool.setuptools.package-dir]
AbletonMCP_UDP = "Ableton-MCP_hybrid-server/AbletonMCP_UDP"
```

## Verification

- `pip install -e .` now completes successfully and builds the editable wheel.
- `python -c "import MCP_Server, elevenlabs_mcp"` works.
- The `ableton-mcp-extended` console script entry point installs correctly.

(Note: `AbletonMCP_UDP` imports `_Framework`, so it can only be imported inside Ableton Live's Remote Script runtime — that's unchanged and unrelated to this packaging fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)